### PR TITLE
Fix screen conversion with ARBCBSCE1

### DIFF
--- a/cheetah/utils.py
+++ b/cheetah/utils.py
@@ -110,7 +110,7 @@ def ocelot2cheetah(element, warnings=True):
         return acc.VerticalCorrector(element.l, element.angle, name=element.id)
     elif isinstance(element, oc.Cavity):
         return acc.Cavity(element.l, name=element.id)
-    elif isinstance(element, oc.Monitor) and "SCR" in element.id:
+    elif isinstance(element, oc.Monitor) and "BSC" in element.id:
         if warnings:
             print(
                 "WARNING: Diagnostic screen was converted with default screen properties."


### PR DESCRIPTION
Fixes #16. Changes the pattern to `"BSC"` which is present in AREABSCR1 and in ARBCBSCE1 and therefore likely going to be more reliable.