### PR TITLE
Fix dependencies on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,9 @@ formats: all
 # Set requirements using conda env
 # conda:
 #   environment: docs/conda_env.yaml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,5 +22,6 @@ python:
       path: .
 
 build:
+  os: ubuntu-22.04
   tools:
-    python: 3.9
+    python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,7 @@ python:
   install:
     - method: pip
       path: .
+
+build:
+  tools:
+    python: 3.9


### PR DESCRIPTION
Broken dependencies caused autodoc to not document the items in each of the modules when building on readthedocs. This should be fixed with this pull request.