### PR TITLE
Add device option for ParameterBeam

### DIFF
--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -97,17 +97,17 @@ class Element:
         if incoming is Beam.empty:
             return incoming
         elif isinstance(incoming, ParameterBeam):
+            if self.device != incoming.device:
+                raise DeviceError
             tm = self.transfer_map(incoming.energy)
             mu = torch.matmul(tm, incoming._mu)
             cov = torch.matmul(tm, torch.matmul(incoming._cov, tm.t()))
-            if self.device != "cpu":
-                raise DeviceError
-            return ParameterBeam(mu, cov, incoming.energy)
+            return ParameterBeam(mu, cov, incoming.energy, device=incoming.device)
         elif isinstance(incoming, ParticleBeam):
-            tm = self.transfer_map(incoming.energy)
-            new_particles = torch.matmul(incoming.particles, tm.t())
             if self.device != incoming.device:
                 raise DeviceError
+            tm = self.transfer_map(incoming.energy)
+            new_particles = torch.matmul(incoming.particles, tm.t())
             return ParticleBeam(new_particles, incoming.energy, device=incoming.device)
         else:
             raise TypeError(f"Parameter incoming is of invalid type {type(incoming)}")

--- a/cheetah/particles.py
+++ b/cheetah/particles.py
@@ -282,11 +282,19 @@ class ParameterBeam(Beam):
     :param mu: Mu vector of the beam.
     :param cov: Covariance matrix of the beam.
     :param energy: Energy of the beam in eV.
+    :param device: Device to use for the beam. If "auto", use CUDA if available.
+        Note: Compuationally it would be faster to use CPU for ParameterBeam.
     """
 
-    def __init__(self, mu: torch.Tensor, cov: torch.Tensor, energy: float) -> None:
-        self._mu = mu
-        self._cov = cov
+    def __init__(
+        self, mu: torch.Tensor, cov: torch.Tensor, energy: float, device: str = "auto"
+    ) -> None:
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device
+
+        self._mu = mu.to(device)
+        self._cov = cov.to(device)
         self.energy = energy
 
     @classmethod
@@ -306,6 +314,7 @@ class ParameterBeam(Beam):
         cor_y: float = 0,
         cor_s: float = 0,
         energy: float = 1e8,
+        device: str = "auto",
     ) -> "ParameterBeam":
         return cls(
             mu=torch.tensor([mu_x, mu_xp, mu_y, mu_yp, 0, 0, 1], dtype=torch.float32),
@@ -322,6 +331,7 @@ class ParameterBeam(Beam):
                 dtype=torch.float32,
             ),
             energy=energy,
+            device=device,
         )
 
     @classmethod
@@ -337,6 +347,7 @@ class ParameterBeam(Beam):
         sigma_p: float = 1e-6,
         cor_s: float = 0,
         energy: float = 1e8,
+        device: str = "auto",
     ) -> "ParameterBeam":
         sigma_x = np.sqrt(emittance_x * beta_x)
         sigma_xp = np.sqrt(emittance_x * (1 + alpha_x**2) / beta_x)
@@ -355,10 +366,11 @@ class ParameterBeam(Beam):
             cor_s=cor_s,
             cor_x=cor_x,
             cor_y=cor_y,
+            device=device,
         )
 
     @classmethod
-    def from_ocelot(cls, parray) -> "ParameterBeam":
+    def from_ocelot(cls, parray, device: str = "auto") -> "ParameterBeam":
         mu = torch.ones(7)
         mu[:6] = torch.tensor(parray.rparticles.mean(axis=1), dtype=torch.float32)
 
@@ -367,7 +379,7 @@ class ParameterBeam(Beam):
 
         energy = 1e9 * parray.E
 
-        return cls(mu=mu, cov=cov, energy=energy)
+        return cls(mu=mu, cov=cov, energy=energy, device=device)
 
     @classmethod
     def from_astra(cls, path: str, **kwargs) -> "ParameterBeam":
@@ -381,7 +393,7 @@ class ParameterBeam(Beam):
         cov = torch.zeros(7, 7)
         cov[:6, :6] = torch.tensor(np.cov(particles.transpose()), dtype=torch.float32)
 
-        return cls(mu=mu, cov=cov, energy=energy)
+        return cls(mu=mu, cov=cov, energy=energy, **kwargs)
 
     def transformed_to(
         self,
@@ -437,6 +449,7 @@ class ParameterBeam(Beam):
             sigma_s=sigma_s,
             sigma_p=sigma_p,
             energy=energy,
+            device=self.device,
         )
 
     @property


### PR DESCRIPTION
- Now one can also specify the `device` for ParameterBeam
  - Added the according option in the doc string
  - Fixed the Element.__call__ device check