### PR TITLE
Fix the transfer map of `Drift` and edge focusing of `Dipole`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ None
 
 ### 🐛 Bug fixes
 
-- Fix the transfer map of Drift; Add R56 in horizontal and vertical correctors modelling (see #90) (@cr-xu)
+- Fix the transfer maps in `Drift` and `Dipole`; Add R56 in horizontal and vertical correctors modelling (see #90) (@cr-xu)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ None
 
 ### 🐛 Bug fixes
 
-None
+- Fix the transfer map of Drift; Add R56 in horizontal and vertical correctors modelling (see #90) (@cr-xu)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -450,8 +450,8 @@ class Dipole(Element):
         return self.angle != 0
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
-        R_enter = self._transfer_map_enter(energy)
-        R_exit = self._transfer_map_exit(energy)
+        R_enter = self._transfer_map_enter()
+        R_exit = self._transfer_map_exit()
 
         if self.length != 0.0:  # Bending magnet with finite length
             R = base_rmatrix(
@@ -477,43 +477,39 @@ class Dipole(Element):
 
         return R
 
-    def _transfer_map_enter(self, energy: torch.Tensor) -> torch.Tensor:
-        if self.fringe_integral == 0:
-            return torch.eye(7, device=self.device)
-        else:
-            sec_e = torch.tensor(1.0) / torch.cos(self.e1)
-            phi = (
-                self.fringe_integral
-                * self.hx
-                * self.gap
-                * sec_e
-                * (1 + torch.sin(self.e1) ** 2)
-            )
+    def _transfer_map_enter(self) -> torch.Tensor:
+        """Linear transfer map for the entrance face of the dipole magnet."""
+        sec_e = torch.tensor(1.0) / torch.cos(self.e1)
+        phi = (
+            self.fringe_integral
+            * self.hx
+            * self.gap
+            * sec_e
+            * (1 + torch.sin(self.e1) ** 2)
+        )
 
-            tm = torch.eye(7, device=self.device)
-            tm[1, 0] = self.hx * torch.tan(self.e1)
-            tm[3, 2] = -self.hx * torch.tan(self.e1 - phi)
+        tm = torch.eye(7, device=self.device)
+        tm[1, 0] = self.hx * torch.tan(self.e1)
+        tm[3, 2] = -self.hx * torch.tan(self.e1 - phi)
 
-            return tm
+        return tm
 
-    def _transfer_map_exit(self, energy: torch.Tensor) -> torch.Tensor:
-        if self.fringe_integral_exit == 0:
-            return torch.eye(7, device=self.device)
-        else:
-            sec_e = 1.0 / torch.cos(self.e2)
-            phi = (
-                self.fringe_integral
-                * self.hx
-                * self.gap
-                * sec_e
-                * (1 + torch.sin(self.e2) ** 2)
-            )
+    def _transfer_map_exit(self) -> torch.Tensor:
+        """Linear transfer map for the exit face of the dipole magnet."""
+        sec_e = 1.0 / torch.cos(self.e2)
+        phi = (
+            self.fringe_integral
+            * self.hx
+            * self.gap
+            * sec_e
+            * (1 + torch.sin(self.e2) ** 2)
+        )
 
-            tm = torch.eye(7, device=self.device)
-            tm[1, 0] = self.hx * torch.tan(self.e2)
-            tm[3, 2] = -self.hx * torch.tan(self.e2 - phi)
+        tm = torch.eye(7, device=self.device)
+        tm[1, 0] = self.hx * torch.tan(self.e2)
+        tm[3, 2] = -self.hx * torch.tan(self.e2 - phi)
 
-            return tm
+        return tm
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
         # TODO: Implement splitting for dipole properly, for now just returns the

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -436,10 +436,12 @@ class Dipole(Element):
         self.e1 = e1 if e1 is not None else torch.tensor(0.0)
         self.e2 = e2 if e2 is not None else torch.tensor(0.0)
 
+    @property
+    def hx(self) -> torch.Tensor:
         if self.length == 0.0:
-            self.hx = torch.tensor(0.0)
+            return torch.tensor(0.0)
         else:
-            self.hx = self.angle / self.length
+            return self.angle / self.length
 
     @property
     def is_skippable(self) -> bool:

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -236,6 +236,9 @@ class Drift(Element):
     """
     Drift section in a particle accelerator.
 
+    Note: the transfer map now uses the linear approximation.
+    Including the R_56 = L / (beta**2 * gamma **2)
+
     :param length: Length in meters.
     :param name: Unique identifier of the element.
     :param device: Device to move the beam's particle array to. If set to `"auto"` a
@@ -255,11 +258,12 @@ class Drift(Element):
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         gamma = energy / rest_energy
         igamma2 = 1 / gamma**2 if gamma != 0 else torch.tensor(0.0)
+        beta = torch.sqrt(1 - igamma2)
 
         tm = torch.eye(7, device=self.device)
         tm[0, 1] = self.length
         tm[2, 3] = self.length
-        tm[4, 5] = self.length * igamma2
+        tm[4, 5] = -self.length / beta**2 * igamma2
 
         return tm
 

--- a/cheetah/track_methods.py
+++ b/cheetah/track_methods.py
@@ -72,7 +72,7 @@ def base_rmatrix(
     beta = torch.sqrt(1 - igamma2)
 
     if k1 == 0:
-        k1 = k1 + torch.tensor(1e-10, device=device)  # Avoid division by zero
+        k1 = k1 + torch.tensor(1e-12, device=device)  # Avoid division by zero
     kx2 = k1 + hx**2
     ky2 = -k1
     kx = torch.sqrt(torch.complex(kx2, torch.tensor(0.0)))
@@ -85,7 +85,7 @@ def base_rmatrix(
     dx = hx / kx2 * (1.0 - cx)
     r56 = hx**2 * (length - sx) / kx2 / beta**2
 
-    r56 -= length / beta**2 * igamma2
+    r56 = r56 - length / beta**2 * igamma2
 
     R = torch.eye(7, dtype=torch.float32, device=device)
     R[0, 0] = cx

--- a/tests/test_compare_ocelot.py
+++ b/tests/test_compare_ocelot.py
@@ -323,24 +323,7 @@ def test_quadrupole():
 
     # Split in order to allow for different tolerances for each particle dimension
     assert np.allclose(
-        outgoing_beam.particles[:, 0], outgoing_p_array.rparticles.transpose()[:, 0]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 1], outgoing_p_array.rparticles.transpose()[:, 1]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 2], outgoing_p_array.rparticles.transpose()[:, 2]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 3], outgoing_p_array.rparticles.transpose()[:, 3]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 4],
-        outgoing_p_array.rparticles.transpose()[:, 4],
-        atol=1e-6,  # TODO: Is this tolerance already too large?
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
+        outgoing_beam.particles[:, :6], outgoing_p_array.rparticles.transpose()
     )
     assert np.allclose(outgoing_beam.particle_charges, outgoing_p_array.q_array)
 
@@ -377,26 +360,8 @@ def test_tilted_quadrupole():
     navigator = ocelot.Navigator(lattice)
     _, outgoing_p_array = ocelot.track(lattice, deepcopy(incoming_p_array), navigator)
 
-    # Split in order to allow for different tolerances for each particle dimension
     assert np.allclose(
-        outgoing_beam.particles[:, 0], outgoing_p_array.rparticles.transpose()[:, 0]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 1], outgoing_p_array.rparticles.transpose()[:, 1]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 2], outgoing_p_array.rparticles.transpose()[:, 2]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 3], outgoing_p_array.rparticles.transpose()[:, 3]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 4],
-        outgoing_p_array.rparticles.transpose()[:, 4],
-        atol=1e-6,  # TODO: Is this tolerance already too large?
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
+        outgoing_beam.particles[:, :6], outgoing_p_array.rparticles.transpose()
     )
     assert np.allclose(outgoing_beam.particle_charges, outgoing_p_array.q_array)
 
@@ -451,7 +416,6 @@ def test_sbend():
     assert np.allclose(
         outgoing_beam.particles[:, 4],
         outgoing_p_array.rparticles.transpose()[:, 4],
-        atol=1e-6,  # TODO: Is this tolerance already too large?
     )
     assert np.allclose(
         outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
@@ -509,7 +473,6 @@ def test_rbend():
     assert np.allclose(
         outgoing_beam.particles[:, 4],
         outgoing_p_array.rparticles.transpose()[:, 4],
-        atol=1e-6,  # TODO: Is this tolerance already too large?
     )
     assert np.allclose(
         outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
@@ -564,7 +527,6 @@ def test_convert_rbend():
     assert np.allclose(
         outgoing_beam.particles[:, 4],
         outgoing_p_array.rparticles.transpose()[:, 4],
-        atol=1e-6,  # TODO: Is this tolerance already too large?
     )
     assert np.allclose(
         outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]

--- a/tests/test_compare_ocelot.py
+++ b/tests/test_compare_ocelot.py
@@ -375,7 +375,7 @@ def test_sbend():
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "benchmark/cheetah/ACHIP_EA1_2021.1351.001"
     )
-    cheetah_dipole = cheetah.Dipole(length=torch.tensor(0.1), angle=torch.tensor(2e-5))
+    cheetah_dipole = cheetah.Dipole(length=torch.tensor(0.1), angle=torch.tensor(0.2))
     cheetah_segment = cheetah.Segment(
         [
             cheetah.Drift(length=torch.tensor(0.1)),
@@ -389,7 +389,7 @@ def test_sbend():
     incoming_p_array = ocelot.astraBeam2particleArray(
         "benchmark/cheetah/ACHIP_EA1_2021.1351.001", print_params=False
     )
-    ocelot_sbend = ocelot.SBend(l=0.1, angle=2e-5)
+    ocelot_sbend = ocelot.SBend(l=0.1, angle=0.2)
     lattice = ocelot.MagneticLattice(
         [ocelot.Drift(l=0.1), ocelot_sbend, ocelot.Drift(l=0.1)]
     )
@@ -398,27 +398,9 @@ def test_sbend():
         lattice, deepcopy(incoming_p_array), navigator, print_progress=False
     )
 
-    # Split in order to allow for different tolerances for each particle dimension
     assert np.allclose(
-        outgoing_beam.particles[:, 0],
-        outgoing_p_array.rparticles.transpose()[:, 0],
-        rtol=1e-3,
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 1], outgoing_p_array.rparticles.transpose()[:, 1]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 2], outgoing_p_array.rparticles.transpose()[:, 2]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 3], outgoing_p_array.rparticles.transpose()[:, 3]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 4],
-        outgoing_p_array.rparticles.transpose()[:, 4],
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
+        outgoing_beam.particles[:, :6],
+        outgoing_p_array.rparticles.transpose(),
     )
     assert np.allclose(outgoing_beam.particle_charges, outgoing_p_array.q_array)
 
@@ -432,7 +414,7 @@ def test_rbend():
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "benchmark/cheetah/ACHIP_EA1_2021.1351.001"
     )
-    cheetah_dipole = cheetah.RBend(length=torch.tensor(0.1), angle=torch.tensor(2e-5))
+    cheetah_dipole = cheetah.RBend(length=torch.tensor(0.1), angle=torch.tensor(0.2))
     cheetah_segment = cheetah.Segment(
         [
             cheetah.Drift(length=torch.tensor(0.1)),
@@ -446,7 +428,7 @@ def test_rbend():
     incoming_p_array = ocelot.astraBeam2particleArray(
         "benchmark/cheetah/ACHIP_EA1_2021.1351.001", print_params=False
     )
-    ocelot_rbend = ocelot.RBend(l=0.1, angle=2e-5)
+    ocelot_rbend = ocelot.RBend(l=0.1, angle=0.2)
     lattice = ocelot.MagneticLattice(
         [ocelot.Drift(l=0.1), ocelot_rbend, ocelot.Drift(l=0.1)]
     )
@@ -455,27 +437,9 @@ def test_rbend():
         lattice, deepcopy(incoming_p_array), navigator, print_progress=False
     )
 
-    # Split in order to allow for different tolerances for each particle dimension
     assert np.allclose(
-        outgoing_beam.particles[:, 0],
-        outgoing_p_array.rparticles.transpose()[:, 0],
-        rtol=1e-3,
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 1], outgoing_p_array.rparticles.transpose()[:, 1]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 2], outgoing_p_array.rparticles.transpose()[:, 2]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 3], outgoing_p_array.rparticles.transpose()[:, 3]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 4],
-        outgoing_p_array.rparticles.transpose()[:, 4],
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
+        outgoing_beam.particles[:, :6],
+        outgoing_p_array.rparticles.transpose(),
     )
     assert np.allclose(outgoing_beam.particle_charges, outgoing_p_array.q_array)
 
@@ -489,7 +453,7 @@ def test_convert_rbend():
     incoming_p_array = ocelot.astraBeam2particleArray(
         "benchmark/cheetah/ACHIP_EA1_2021.1351.001", print_params=False
     )
-    ocelot_rbend = ocelot.RBend(l=0.1, angle=2e-5, gap=0.05, fint=0.1, eid="rbend")
+    ocelot_rbend = ocelot.RBend(l=0.1, angle=0.2, gap=0.05, fint=0.1, eid="rbend")
     lattice = ocelot.MagneticLattice(
         [
             ocelot.Drift(l=0.1, eid="drfit_1"),
@@ -509,27 +473,8 @@ def test_convert_rbend():
     cheetah_segment = cheetah.Segment.from_ocelot(lattice.sequence)
     outgoing_beam = cheetah_segment.track(incoming_beam)
 
-    # Split in order to allow for different tolerances for each particle dimension
     assert np.allclose(
-        outgoing_beam.particles[:, 0],
-        outgoing_p_array.rparticles.transpose()[:, 0],
-        rtol=1e-3,
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 1], outgoing_p_array.rparticles.transpose()[:, 1]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 2], outgoing_p_array.rparticles.transpose()[:, 2]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 3], outgoing_p_array.rparticles.transpose()[:, 3]
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 4],
-        outgoing_p_array.rparticles.transpose()[:, 4],
-    )
-    assert np.allclose(
-        outgoing_beam.particles[:, 5], outgoing_p_array.rparticles.transpose()[:, 5]
+        outgoing_beam.particles[:, :6], outgoing_p_array.rparticles.transpose()
     )
     assert np.allclose(outgoing_beam.particle_charges, outgoing_p_array.q_array)
 


### PR DESCRIPTION
- Fix the R_56 component of the transfer map in `Drift`;
- Updated the test functions, now the difference should be less.
- Add R_56 component in `VerticalCorrector` and `HorizontalCorrector`
- Fix the edge focusing transfer maps for bends (e.g. `Dipole` `RBend` and `SBend`)
- Removed the large tolerances for result comparison in test functions