### PR TITLE
Fix links to format and pytest badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="images/logo.png" align="right" width="25%"/>
 
-![format](https://github.com/desy-ml/cheetah/actions/workflows/format.yml/badge.svg)
-![pytest](https://github.com/desy-ml/cheetah/actions/workflows/pytest.yml/badge.svg)
+![format](https://github.com/desy-ml/cheetah/actions/workflows/format.yaml/badge.svg)
+![pytest](https://github.com/desy-ml/cheetah/actions/workflows/pytest.yaml/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/cheetah-accelerator/badge/?version=latest)](https://cheetah-accelerator.readthedocs.io/en/latest/?badge=latest)
 [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
## Description

Change the `.yml` file endings in the badge links to `.yaml`.

## Motivation and Context

The links were broken in a recent change when the file endings of the workflows were changed(#104).

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [x] I have updated the documentation accordingly.
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line