### PR TITLE
Fix ASTRA beam import energy dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ None
 - Fix fringe_field_exit of `Dipole` is overwritten by `fringe_field` bug (see #99) (@cr-xu)
 - Fix error caused by mismatched devices on machines with CUDA GPUs (see #97) (@jank324)
 - Fix error raised when tracking a `ParameterBeam` through an active `BPM` (see #101) (@jank324)
+- Fix error in ASTRA beam import where the energy was set to `float64` instead of `float32` (see #111) (@jank324)
 
 ### 🐆 Other
 

--- a/cheetah/particles.py
+++ b/cheetah/particles.py
@@ -467,7 +467,7 @@ class ParameterBeam(Beam):
         return cls(
             mu=mu,
             cov=cov,
-            energy=torch.tensor(energy),
+            energy=torch.tensor(energy, dtype=torch.float32),
             total_charge=total_charge,
             **kwargs,
         )

--- a/cheetah/particles.py
+++ b/cheetah/particles.py
@@ -905,7 +905,7 @@ class ParticleBeam(Beam):
         particle_charges = torch.from_numpy(particle_charges)
         return cls(
             particles=particles_7d,
-            energy=torch.tensor(energy),
+            energy=torch.tensor(energy, dtype=torch.float32),
             particle_charges=particle_charges,
             **kwargs,
         )

--- a/tests/test_astra_import.py
+++ b/tests/test_astra_import.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 import cheetah
 
@@ -40,3 +41,21 @@ def test_astra_to_particle_beam():
     assert np.allclose(beam.sigma_p.cpu().numpy(), 0.0022804534528404474)
     assert np.allclose(beam.energy.cpu().numpy(), 107315902.44394557)
     assert np.allclose(beam.total_charge.cpu().numpy(), 5.000000000010205e-13)
+
+
+def test_astra_to_parameter_beam_dtypes():
+    """Test that Astra beams are correctly loaded into particle beams."""
+    beam = cheetah.ParameterBeam.from_astra("tests/resources/ACHIP_EA1_2021.1351.001")
+
+    assert beam.mu_x.dtype == torch.float32
+    assert beam.mu_xp.dtype == torch.float32
+    assert beam.mu_y.dtype == torch.float32
+    assert beam.mu_yp.dtype == torch.float32
+    assert beam.sigma_x.dtype == torch.float32
+    assert beam.sigma_xp.dtype == torch.float32
+    assert beam.sigma_y.dtype == torch.float32
+    assert beam.sigma_yp.dtype == torch.float32
+    assert beam.sigma_s.dtype == torch.float32
+    assert beam.sigma_p.dtype == torch.float32
+    assert beam.energy.dtype == torch.float32
+    assert beam.total_charge.dtype == torch.float32


### PR DESCRIPTION
Convert the dtype of `energy` to `torch.float32` in the conversion from an ASTRA beam.

## Motivation and Context

Cheetah should use `torch.float32` internally (for now). Fixes #110.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line