### PR TITLE
Fix cavity `__repr__` printing volate for phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix error raised when tracking a `ParameterBeam` through an active `BPM` (see #101) (@jank324)
 - Fix error in ASTRA beam import where the energy was set to `float64` instead of `float32` (see #111) (@jank324)
 - Fix missing passing of `total_charge` in `ParameterBeam.transformed_to` (see #112) (@jank324)
+- Fix `Cavitiy.__repr__` printing `voltage` value for `phase` property (see #121) (@jank324)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -23,9 +23,7 @@ from cheetah.utils import UniqueNameGenerator
 generate_unique_name = UniqueNameGenerator(prefix="unnamed_element")
 
 rest_energy = torch.tensor(
-    constants.electron_mass
-    * constants.speed_of_light**2
-    / constants.elementary_charge
+    constants.electron_mass * constants.speed_of_light**2 / constants.elementary_charge
 )  # electron mass
 electron_mass_eV = torch.tensor(
     physical_constants["electron mass energy equivalent in MeV"][0] * 1e6

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -1163,7 +1163,7 @@ class Cavity(Element):
         return (
             f"{self.__class__.__name__}(length={repr(self.length)}, "
             + f"voltage={repr(self.voltage)}, "
-            + f"phase={repr(self.voltage)}, "
+            + f"phase={repr(self.phase)}, "
             + f"frequency={repr(self.frequency)}, "
             + f"name={repr(self.name)})"
         )

--- a/cheetah/track_methods.py
+++ b/cheetah/track_methods.py
@@ -6,9 +6,7 @@ import torch
 from scipy import constants
 
 REST_ENERGY = torch.tensor(
-    constants.electron_mass
-    * constants.speed_of_light**2
-    / constants.elementary_charge
+    constants.electron_mass * constants.speed_of_light**2 / constants.elementary_charge
 )  # Electron mass
 
 

--- a/tests/test_compare_beam_type.py
+++ b/tests/test_compare_beam_type.py
@@ -1,6 +1,7 @@
 """
 Tests that ensure that both beam types produce (roughly) the same results.
 """
+
 import torch
 
 import cheetah


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixes the `__repr__` bug in `Cavity` as found in #120.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Closes #120.

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
