### PR TITLE
Fix cavity transfer map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### 🐆 Other
 
-# Changelog
-
 ## v0.6.3 [🚧 Work in Progress]
 
 ### 🚨 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ### 🐛 Bug fixes
 
+### 🐆 Other
+
+# Changelog
+
+## v0.6.3 [🚧 Work in Progress]
+
+### 🚨 Breaking Changes
+
+### 🚀 Features
+
+### 🐛 Bug fixes
+
 - Fix bug in `Cavity` transfer map bug. (see #128) (@cr-xu)
 
 ### 🐆 Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug in `Cavity` transfer map bug. (see #128) (@cr-xu)
+
 ### 🐆 Other
 
 ## [v0.6.2](https://github.com/desy-ml/cheetah/releases/tag/v0.6.2) (2024-02-13)

--- a/cheetah/accelerator.py
+++ b/cheetah/accelerator.py
@@ -940,6 +940,7 @@ class Cavity(Element):
         T566 = 1.5 * self.length * igamma2 / beta0**3
         T556 = 0
         T555 = 0
+
         if incoming.energy + delta_energy > 0:
             k = 2 * torch.pi * self.frequency / constants.speed_of_light
             outgoing_energy = incoming.energy + delta_energy
@@ -947,34 +948,23 @@ class Cavity(Element):
             beta1 = torch.sqrt(1 - 1 / g1**2)
 
             if isinstance(incoming, ParameterBeam):
-                outgoing_mu[5] = (
-                    incoming._mu[5]
-                    + incoming.energy * beta0 / (outgoing_energy * beta1)
-                    + self.voltage
-                    * beta0
-                    / (outgoing_energy * beta1)
-                    * (torch.cos(incoming._mu[4] * beta0 * k + phi) - torch.cos(phi))
+                outgoing_mu[5] = incoming._mu[5] * incoming.energy * beta0 / (
+                    outgoing_energy * beta1
+                ) + self.voltage * beta0 / (outgoing_energy * beta1) * (
+                    torch.cos(-incoming._mu[4] * beta0 * k + phi) - torch.cos(phi)
                 )
                 outgoing_cov[5, 5] = incoming._cov[5, 5]
-                # outgoing_cov[5, 5] = (
-                #     incoming._cov[5, 5]
-                #     + incoming.energy * beta0 / (outgoing_energy * beta1)
-                #     + self.voltage
-                #     * beta0
-                #     / (outgoing_energy * beta1)
-                #     * (torch.cos(incoming._mu[4] * beta0 * k + phi) - torch.cos(phi))
-                # )
+
             else:  # ParticleBeam
-                outgoing_particles[:, 5] = (
-                    incoming.particles[:, 5]
-                    + incoming.energy * beta0 / (outgoing_energy * beta1)
-                    + self.voltage
-                    * beta0
-                    / (outgoing_energy * beta1)
-                    * (
-                        torch.cos(incoming.particles[:, 4] * beta0 * k + phi)
-                        - torch.cos(phi)
-                    )
+                outgoing_particles[:, 5] = incoming.particles[
+                    :, 5
+                ] * incoming.energy * beta0 / (
+                    outgoing_energy * beta1
+                ) + self.voltage * beta0 / (
+                    outgoing_energy * beta1
+                ) * (
+                    torch.cos(-incoming.particles[:, 4] * beta0 * k + phi)
+                    - torch.cos(phi)
                 )
 
             dgamma = self.voltage / electron_mass_eV
@@ -1017,7 +1007,7 @@ class Cavity(Element):
                 )
 
             if isinstance(incoming, ParameterBeam):
-                outgoing_mu[4] = (
+                outgoing_mu[4] = incoming._mu[4] + (
                     T566 * incoming._mu[5] ** 2
                     + T556 * incoming._mu[4] * incoming._mu[5]
                     + T555 * incoming._mu[4] ** 2
@@ -1034,7 +1024,7 @@ class Cavity(Element):
                 )
                 outgoing_cov[5, 4] = outgoing_cov[4, 5]
             else:  # ParticleBeam
-                outgoing_particles[:, 4] = (
+                outgoing_particles[:, 4] = incoming.particles[:, 4] + (
                     T566 * incoming.particles[:, 5] ** 2
                     + T556 * incoming.particles[:, 4] * incoming.particles[:, 5]
                     + T555 * incoming.particles[:, 4] ** 2

--- a/tests/test_compare_ocelot.py
+++ b/tests/test_compare_ocelot.py
@@ -645,12 +645,21 @@ def test_cavity():
     # Compare
     assert np.isclose(outgoing_beam.beta_x.cpu().numpy(), derived_twiss.beta_x)
     assert np.isclose(
-        outgoing_beam.alpha_x.cpu().numpy(), derived_twiss.alpha_x, rtol=1e-4
+        outgoing_beam.alpha_x.cpu().numpy(), derived_twiss.alpha_x, rtol=2e-5
     )
     assert np.isclose(outgoing_beam.beta_y.cpu().numpy(), derived_twiss.beta_y)
     assert np.isclose(
-        outgoing_beam.alpha_y.cpu().numpy(), derived_twiss.alpha_y, rtol=1e-4
+        outgoing_beam.alpha_y.cpu().numpy(), derived_twiss.alpha_y, rtol=2e-5
     )
     assert np.isclose(
         outgoing_beam.total_charge.cpu().numpy(), np.sum(outgoing_parray.q_array)
+    )
+    assert np.allclose(
+        outgoing_beam.particles[:, 5].cpu().numpy(),
+        outgoing_parray.rparticles.transpose()[:, 5],
+    )
+    assert np.allclose(
+        outgoing_beam.particles[:, 4].cpu().numpy(),
+        outgoing_parray.rparticles.transpose()[:, 4],
+        atol=1e-4,
     )


### PR DESCRIPTION
- Fixed the cavity transfer map, now tracking `s` and `p` components correctly
- Update CHANGELOG.md

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
