### PR TITLE
Fix dipole tracking issue; Add tests accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚨 Breaking Changes
 
-- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157) (@jank324, @cr-xu)
+- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170) (@jank324, @cr-xu)
 
 ### 🚀 Features
 

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -120,7 +120,7 @@ class Dipole(Element):
         R_enter = self._transfer_map_enter()
         R_exit = self._transfer_map_exit()
 
-        if self.length != 0.0:  # Bending magnet with finite length
+        if any(self.length != 0.0):  # Bending magnet with finite length
             R = base_rmatrix(
                 length=self.length,
                 k1=torch.zeros_like(self.length),

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -5,7 +5,7 @@ from cheetah import Dipole, Drift, ParameterBeam, ParticleBeam, Segment
 
 def test_dipole_off():
     """
-    Test that a dipole with k1=0 behaves still like a drift.
+    Test that a dipole with angle=0 behaves still like a drift.
     """
     dipole = Dipole(length=torch.tensor([1.0]), angle=torch.tensor([0.0]))
     drift = Drift(length=torch.tensor([1.0]))
@@ -43,8 +43,8 @@ def test_dipole_batched_execution():
     )
     outgoing = segment(incoming)
 
-    # Check pi/4 and 5/4*pi rotations is the same for quadrupole
+    # Check that dipole with same bend angle produce same output
     assert torch.allclose(outgoing.particles[0], outgoing.particles[2])
 
-    # Check pi/2 rotation is different
+    # Check different angles do make a difference
     assert not torch.allclose(outgoing.particles[0], outgoing.particles[1])

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -1,0 +1,50 @@
+import torch
+
+from cheetah import Dipole, Drift, ParameterBeam, ParticleBeam, Segment
+
+
+def test_dipole_off():
+    """
+    Test that a dipole with k1=0 behaves still like a drift.
+    """
+    dipole = Dipole(length=torch.tensor([1.0]), angle=torch.tensor([0.0]))
+    drift = Drift(length=torch.tensor([1.0]))
+    incoming_beam = ParameterBeam.from_parameters(
+        sigma_xp=torch.tensor([2e-7]), sigma_yp=torch.tensor([2e-7])
+    )
+    outbeam_dipole_off = dipole(incoming_beam)
+    outbeam_drift = drift(incoming_beam)
+
+    dipole.angle = torch.tensor([1.0], device=dipole.angle.device)
+    outbeam_dipole_on = dipole(incoming_beam)
+
+    assert torch.allclose(outbeam_dipole_off.sigma_x, outbeam_drift.sigma_x)
+    assert not torch.allclose(outbeam_dipole_on.sigma_x, outbeam_drift.sigma_x)
+
+
+def test_dipole_batched_execution():
+    """
+    Test that a dipole with batch dimensions behaves as expected.
+    """
+    batch_shape = torch.Size([3])
+    incoming = ParticleBeam.from_parameters(
+        num_particles=torch.tensor(1000000),
+        energy=torch.tensor([1e9]),
+        mu_x=torch.tensor([1e-5]),
+    ).broadcast(batch_shape)
+    segment = Segment(
+        [
+            Dipole(
+                length=torch.tensor([0.5, 0.5, 0.5]),
+                angle=torch.tensor([0.1, 0.2, 0.1]),
+            ),
+            Drift(length=torch.tensor([0.5])).broadcast(batch_shape),
+        ]
+    )
+    outgoing = segment(incoming)
+
+    # Check pi/4 and 5/4*pi rotations is the same for quadrupole
+    assert torch.allclose(outgoing.particles[0], outgoing.particles[2])
+
+    # Check pi/2 rotation is different
+    assert not torch.allclose(outgoing.particles[0], outgoing.particles[1])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

A bug fix related to #100 for dipole tracking.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
