### PR TITLE
Implement Bmad conversion device passing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,13 @@
 {
-    "spellright.language": [
-        "en_GB"
-    ],
-    "spellright.documentTypes": [
-        "markdown",
-        "latex",
-        "plaintext"
-    ],
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "python.formatting.provider": "none",
-    "esbonio.sphinx.confDir": ""
+  "spellright.language": ["en_GB"],
+  "spellright.documentTypes": ["markdown", "latex", "plaintext"],
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "python.formatting.provider": "none",
+  "esbonio.sphinx.confDir": "",
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add a new class method for `ParticleBeam` to generate a 3D uniformly distributed ellipsoidal beam (see #146) (@cr-xu, @jank324)
 - Add Python 3.12 support (see #161) (@jank324)
 - Implement space charge using Green's function in a `SpaceChargeKick` element (see #142) (@greglenerd, @RemiLehe, @ax3l, @cr-xu, @jank324)
+- `Segment`s can now be imported from Bmad to devices other than `torch.device("cpu")` (see #196) (@jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -272,7 +272,10 @@ class Segment(Element):
 
     @classmethod
     def from_bmad(
-        cls, bmad_lattice_file_path: str, environment_variables: Optional[dict] = None
+        cls,
+        bmad_lattice_file_path: str,
+        environment_variables: Optional[dict] = None,
+        device: Optional[Union[str, torch.device]] = None,
     ) -> "Segment":
         """
         Read a Cheetah segment from a Bmad lattice file.
@@ -285,10 +288,13 @@ class Segment(Element):
         :param bmad_lattice_file_path: Path to the Bmad lattice file.
         :param environment_variables: Dictionary of environment variables to use when
             parsing the lattice file.
+        :param device: Device to place the lattice elements on.
         :return: Cheetah `Segment` representing the Bmad lattice.
         """
         bmad_lattice_file_path = Path(bmad_lattice_file_path)
-        return convert_bmad_lattice(bmad_lattice_file_path, environment_variables)
+        return convert_bmad_lattice(
+            bmad_lattice_file_path, environment_variables, device
+        )
 
     @classmethod
     def from_nx_tables(cls, filepath: Union[Path, str]) -> "Element":

--- a/tests/test_bmad_conversion.py
+++ b/tests/test_bmad_conversion.py
@@ -31,3 +31,26 @@ def test_bmad_tutorial():
     assert converted.b.e1 == correct.b.e1
     assert converted.q.length == correct.q.length
     assert converted.q.k1 == correct.q.k1
+
+
+def test_device_passing():
+    """Test that the device is passed correctly."""
+    file_path = "tests/resources/bmad_tutorial_lattice.bmad"
+
+    # Check if CUDA or MPS are available
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+
+    # Convert the lattice while passing the device
+    converted = cheetah.Segment.from_bmad(file_path, device=device)
+
+    # Check that the properties of the loaded elements are on the correct device
+    assert converted.d.length.device == torch.device("cpu")
+    assert converted.b.length.device == torch.device("cpu")
+    assert converted.b.e1.device == torch.device("cpu")
+    assert converted.q.length.device == torch.device("cpu")
+    assert converted.q.k1.device == torch.device("cpu")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Makes sure that `device` can be passed to the element initialisations when using `Segment.from_bmad`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

This is needed to be able to load Bmad lattices on a device other than `"cpu"`. Closes #195.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [x] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [x] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
