### PR TITLE
Add `dtype` passing to Bmad `Segment` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix issue where dipoles would not get a unique name by default (see #186) (@hespe)
 - Add `name` to `Drift` element `__repr__` (see #201) (@ansantam)
 - Fix bug where `dtype` was not used when creating a `ParameterBeam` from Twiss parameters (see #206) (@jank324)
+- Fix bug after running `Segment.inactive_elements_as_drifts` the drifts could have the wrong `dtype` (see #206) (@jank324)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix bug in `Cavity` `_track_beam` (see #150) (@jp-ga)
 - Fix issue where dipoles would not get a unique name by default (see #186) (@hespe)
 - Add `name` to `Drift` element `__repr__` (see #201) (@ansantam)
+- Fix bug where `dtype` was not used when creating a `ParameterBeam` from Twiss parameters (see #206) (@jank324)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add a new class method for `ParticleBeam` to generate a 3D uniformly distributed ellipsoidal beam (see #146) (@cr-xu, @jank324)
 - Add Python 3.12 support (see #161) (@jank324)
 - Implement space charge using Green's function in a `SpaceChargeKick` element (see #142) (@greglenerd, @RemiLehe, @ax3l, @cr-xu, @jank324)
-- `Segment`s can now be imported from Bmad to devices other than `torch.device("cpu")` (see #196) (@jank324)
+- `Segment`s can now be imported from Bmad to devices other than `torch.device("cpu")` and dtypes other than `torch.float32` (see #196, #206) (@jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -202,7 +202,11 @@ class Segment(Element):
                     if (hasattr(element, "is_active") and element.is_active)
                     or element.length == 0.0
                     or element.name in except_for
-                    else Drift(element.length)
+                    else Drift(
+                        element.length,
+                        device=element.length.device,
+                        dtype=element.length.dtype,
+                    )
                 )
                 for element in self.elements
             ],

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -276,6 +276,7 @@ class Segment(Element):
         bmad_lattice_file_path: str,
         environment_variables: Optional[dict] = None,
         device: Optional[Union[str, torch.device]] = None,
+        dtype: torch.dtype = torch.float32,
     ) -> "Segment":
         """
         Read a Cheetah segment from a Bmad lattice file.
@@ -289,11 +290,12 @@ class Segment(Element):
         :param environment_variables: Dictionary of environment variables to use when
             parsing the lattice file.
         :param device: Device to place the lattice elements on.
+        :param dtype: Data type to use for the lattice elements.
         :return: Cheetah `Segment` representing the Bmad lattice.
         """
         bmad_lattice_file_path = Path(bmad_lattice_file_path)
         return convert_bmad_lattice(
-            bmad_lattice_file_path, environment_variables, device
+            bmad_lattice_file_path, environment_variables, device, dtype
         )
 
     @classmethod

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -60,8 +60,13 @@ class Beam(nn.Module):
         beta_y: Optional[torch.Tensor] = None,
         alpha_y: Optional[torch.Tensor] = None,
         emittance_y: Optional[torch.Tensor] = None,
+        sigma_s: Optional[torch.Tensor] = None,
+        sigma_p: Optional[torch.Tensor] = None,
+        cor_s: Optional[torch.Tensor] = None,
         energy: Optional[torch.Tensor] = None,
         total_charge: Optional[torch.Tensor] = None,
+        device=None,
+        dtype=torch.float32,
     ) -> "Beam":
         """
         Create a beam from twiss parameters.
@@ -72,8 +77,13 @@ class Beam(nn.Module):
         :param beta_y: Beta function in y direction in meters.
         :param alpha_y: Alpha function in y direction in rad.
         :param emittance_y: Emittance in y direction in m*rad.
+        :param sigma_s: Sigma of the particle distribution in s direction in meters.
+        :param sigma_p: Sigma of the particle distribution in p direction in meters.
+        :param cor_s: Correlation of the particle distribution in s direction.
         :param energy: Energy of the beam in eV.
         :param total_charge: Total charge of the beam in C.
+        :param device: Device to create the beam on.
+        :param dtype: Data type of the beam.
         """
         raise NotImplementedError
 

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -136,7 +136,12 @@ class ParameterBeam(Beam):
         cov[..., 5, 5] = sigma_p**2
 
         return cls(
-            mu=mu, cov=cov, energy=energy, total_charge=total_charge, device=device
+            mu=mu,
+            cov=cov,
+            energy=energy,
+            total_charge=total_charge,
+            device=device,
+            dtype=dtype,
         )
 
     @classmethod
@@ -225,6 +230,7 @@ class ParameterBeam(Beam):
             cor_y=cor_y,
             total_charge=total_charge,
             device=device,
+            dtype=dtype,
         )
 
     @classmethod

--- a/tests/test_bmad_conversion.py
+++ b/tests/test_bmad_conversion.py
@@ -65,3 +65,19 @@ def test_device_passing(device: torch.device):
     assert converted.b.e1.device.type == device.type
     assert converted.q.length.device.type == device.type
     assert converted.q.k1.device.type == device.type
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_passing(dtype: torch.dtype):
+    """Test that the dtype is passed correctly."""
+    file_path = "tests/resources/bmad_tutorial_lattice.bmad"
+
+    # Convert the lattice while passing the dtype
+    converted = cheetah.Segment.from_bmad(file_path, dtype=dtype)
+
+    # Check that the properties of the loaded elements are of the correct dtype
+    assert converted.d.length.dtype == dtype
+    assert converted.b.length.dtype == dtype
+    assert converted.b.e1.dtype == dtype
+    assert converted.q.length.dtype == dtype
+    assert converted.q.k1.dtype == dtype

--- a/tests/test_parameter_beam.py
+++ b/tests/test_parameter_beam.py
@@ -96,3 +96,30 @@ def test_from_twiss_to_twiss():
     assert np.isclose(beam.alpha_y.cpu().numpy(), 2e-7)
     assert np.isclose(beam.emittance_y.cpu().numpy(), 3.497810737006068e-09)
     assert np.isclose(beam.energy.cpu().numpy(), 6e6)
+
+
+def test_from_twiss_dtype():
+    """
+    Test that a `ParameterBeam` created from twiss parameters has the requested `dtype`.
+    """
+    beam = ParameterBeam.from_twiss(
+        beta_x=torch.tensor([5.91253676811640894]),
+        alpha_x=torch.tensor([3.55631307633660354]),
+        emittance_x=torch.tensor([3.494768647122823e-09]),
+        beta_y=torch.tensor([5.91253676811640982]),
+        alpha_y=torch.tensor([2e-7]),
+        emittance_y=torch.tensor([3.497810737006068e-09]),
+        energy=torch.tensor([6e6]),
+        dtype=torch.float64,
+    )
+
+    assert np.isclose(beam.beta_x.cpu().numpy(), 5.91253676811640894)
+    assert np.isclose(beam.alpha_x.cpu().numpy(), 3.55631307633660354)
+    assert np.isclose(beam.emittance_x.cpu().numpy(), 3.494768647122823e-09)
+    assert np.isclose(beam.beta_y.cpu().numpy(), 5.91253676811640982)
+    assert np.isclose(beam.alpha_y.cpu().numpy(), 2e-7)
+    assert np.isclose(beam.emittance_y.cpu().numpy(), 3.497810737006068e-09)
+    assert np.isclose(beam.energy.cpu().numpy(), 6e6)
+
+    assert beam._mu.dtype == torch.float64
+    assert beam._cov.dtype == torch.float64

--- a/tests/test_speed_optimizations.py
+++ b/tests/test_speed_optimizations.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 import cheetah
@@ -160,6 +161,27 @@ def test_active_elements_not_replaced_by_drift():
     optimized_segment = segment.inactive_elements_as_drifts()
 
     assert isinstance(optimized_segment.elements[1], cheetah.Quadrupole)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_inactive_magnet_drift_replacement_dtype(dtype: torch.dtype):
+    """
+    Test that when an inactive magnet is replaced by a drift, the drift has the same
+    dtype as the original element.
+    """
+    segment = cheetah.Segment(
+        elements=[
+            cheetah.Drift(length=torch.tensor([0.6]), dtype=dtype),
+            cheetah.Quadrupole(
+                length=torch.tensor([0.2]), k1=torch.tensor([0.0]), dtype=dtype
+            ),
+            cheetah.Drift(length=torch.tensor([0.4]), dtype=dtype),
+        ]
+    )
+
+    optimized_segment = segment.inactive_elements_as_drifts()
+
+    assert all(element.length.dtype == dtype for element in optimized_segment.elements)
 
 
 def test_skippable_elements_reset():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Let's users pass the `dtype` when creating a `Segment` from a Bmad lattice.

Also fixes a bug where passing `dtype` to `ParameterBeam.from_twiss` had no effect.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Solves #204. Related to #195 and #196.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [x] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
