### PR TITLE
203 new corrector class

### DIFF
--- a/cheetah/__init__.py
+++ b/cheetah/__init__.py
@@ -3,6 +3,7 @@ from cheetah.accelerator import (  # noqa: F401
     BPM,
     Aperture,
     Cavity,
+    Corrector,
     CustomTransferMap,
     Dipole,
     Drift,

--- a/cheetah/accelerator/__init__.py
+++ b/cheetah/accelerator/__init__.py
@@ -1,6 +1,7 @@
 from .aperture import Aperture  # noqa: F401
 from .bpm import BPM  # noqa: F401
 from .cavity import Cavity  # noqa: F401
+from .corrector import Corrector  # noqa: F401
 from .custom_transfer_map import CustomTransferMap  # noqa: F401
 from .dipole import Dipole  # noqa: F401
 from .drift import Drift  # noqa: F401

--- a/cheetah/accelerator/corrector.py
+++ b/cheetah/accelerator/corrector.py
@@ -1,0 +1,175 @@
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from matplotlib.patches import Rectangle
+from scipy.constants import physical_constants
+from torch import Size, nn
+
+from cheetah.utils import UniqueNameGenerator
+
+from .element import Element
+
+generate_unique_name = UniqueNameGenerator(prefix="unnamed_element")
+
+electron_mass_eV = torch.tensor(
+    physical_constants["electron mass energy equivalent in MeV"][0] * 1e6
+)
+
+
+class Corrector(Element):
+    """
+    Corrector magnet in a particle accelerator.
+    Note: This is modeled as a drift section with
+        a thin-kick in the horizontal plane followed by
+        a thin-kick in the vertical plane.
+
+    :param length: Length in meters.
+    :param horizontal_angle: Particle deflection horizontal_angle in
+        the horizontal plane in rad.
+    :param vertical_angle: Particle deflection vertical_angle in
+        the vertical plane in rad.
+    :param name: Unique identifier of the element.
+    """
+
+    def __init__(
+        self,
+        length: Union[torch.Tensor, nn.Parameter],
+        horizontal_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        vertical_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        name: Optional[str] = None,
+        device=None,
+        dtype=torch.float32,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__(name=name)
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        self.horizontal_angle = (
+            torch.as_tensor(horizontal_angle, **factory_kwargs)
+            if horizontal_angle is not None
+            else torch.zeros_like(self.length)
+        )
+        self.vertical_angle = (
+            torch.as_tensor(vertical_angle, **factory_kwargs)
+            if vertical_angle is not None
+            else torch.zeros_like(self.length)
+        )
+
+    def horizontal_transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
+        device = self.length.device
+        dtype = self.length.dtype
+
+        gamma = energy / electron_mass_eV.to(device=device, dtype=dtype)
+        igamma2 = torch.zeros_like(gamma)  # TODO: Effect on gradients?
+        igamma2[gamma != 0] = 1 / gamma[gamma != 0] ** 2
+        beta = torch.sqrt(1 - igamma2)
+
+        h_tm = torch.eye(7, device=device, dtype=dtype).repeat(
+            (*self.length.shape, 1, 1)
+        )
+        h_tm[..., 0, 1] = self.length
+        h_tm[..., 1, 6] = self.horizontal_angle
+        h_tm[..., 2, 3] = self.length
+        h_tm[..., 4, 5] = -self.length / beta**2 * igamma2
+
+        # print(h_tm)
+
+        return h_tm
+
+    def vertical_transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
+        device = self.length.device
+        dtype = self.length.dtype
+
+        gamma = energy / electron_mass_eV.to(device=device, dtype=dtype)
+        igamma2 = torch.zeros_like(gamma)  # TODO: Effect on gradients?
+        igamma2[gamma != 0] = 1 / gamma[gamma != 0] ** 2
+        beta = torch.sqrt(1 - igamma2)
+
+        v_tm = torch.eye(7, device=device, dtype=dtype).repeat(
+            (*self.length.shape, 1, 1)
+        )
+        v_tm[..., 0, 1] = self.length
+        v_tm[..., 2, 3] = self.length
+        v_tm[..., 3, 6] = self.vertical_angle
+        v_tm[..., 4, 5] = -self.length / beta**2 * igamma2
+
+        # print(v_tm)
+
+        return v_tm
+
+    def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
+        device = self.length.device
+        dtype = self.length.dtype
+
+        gamma = energy / electron_mass_eV.to(device=device, dtype=dtype)
+        igamma2 = torch.zeros_like(gamma)  # TODO: Effect on gradients?
+        igamma2[gamma != 0] = 1 / gamma[gamma != 0] ** 2
+        beta = torch.sqrt(1 - igamma2)
+
+        tm = torch.eye(7, device=device, dtype=dtype).repeat((*self.length.shape, 1, 1))
+        tm[..., 0, 1] = self.length
+        tm[..., 2, 3] = self.length
+        tm[..., 1, 6] = self.horizontal_angle
+        tm[..., 3, 6] = self.vertical_angle
+        tm[..., 4, 5] = -self.length / beta**2 * igamma2
+
+        return tm
+
+    def broadcast(self, shape: Size) -> Element:
+        return self.__class__(
+            length=self.length.repeat(shape),
+            horizontal_angle=self.horizontal_angle,
+            vertical_angle=self.vertical_angle,
+            name=self.name,
+        )
+
+    @property
+    def is_skippable(self) -> bool:
+        return True
+
+    @property
+    def is_active(self) -> bool:
+        return any(self.horizontal_angle != 0, self.vertical_angle != 0)
+
+    def split(self, resolution: torch.Tensor) -> list[Element]:
+        split_elements = []
+        remaining = self.length
+        while remaining > 0:
+            length = torch.min(resolution, remaining)
+            element = Corrector(
+                length,
+                self.horizontal_angle * length / self.length,
+                self.vertical_angle * length / self.length,
+            )
+            split_elements.append(element)
+            remaining -= resolution
+        return split_elements
+
+    def plot(self, ax: plt.Axes, s: float) -> None:
+        alpha = 1 if self.is_active else 0.2
+        height = (np.sign(self.horizontal_angle[0]) if self.is_active else 1) * (
+            np.sign(self.vertical_angle[0]) if self.is_active else 1
+        )
+
+        patch = Rectangle(
+            (s, 0), self.length[0], height, color="tab:blue", alpha=alpha, zorder=2
+        )
+        ax.add_patch(patch)
+
+    @property
+    def defining_features(self) -> list[str]:
+        return super().defining_features + [
+            "length",
+            "horizontal_angle",
+            "vertical_angle",
+        ]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(length={repr(self.length)}, "
+            + f"horizontal_angle={repr(self.horizontal_angle)}, "
+            + f"vertical_angle={repr(self.vertical_angle)}, "
+            + f"name={repr(self.name)})"
+        )

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -1,108 +1,39 @@
 from typing import Optional, Union
 
-import matplotlib.pyplot as plt
-import numpy as np
 import torch
-from matplotlib.patches import Rectangle
-from scipy.constants import physical_constants
-from torch import Size, nn
+from torch import nn
 
 from cheetah.utils import UniqueNameGenerator
 
-from .element import Element
+from .corrector import Corrector
 
 generate_unique_name = UniqueNameGenerator(prefix="unnamed_element")
 
-electron_mass_eV = torch.tensor(
-    physical_constants["electron mass energy equivalent in MeV"][0] * 1e6
-)
 
-
-class HorizontalCorrector(Element):
+class HorizontalCorrector(Corrector):
     """
     Horizontal corrector magnet in a particle accelerator.
     Note: This is modeled as a drift section with
         a thin-kick in the horizontal plane.
 
     :param length: Length in meters.
-    :param angle: Particle deflection angle in the horizontal plane in rad.
+    :param horizontal_angle: Particle deflection angle in the horizontal plane in rad.
     :param name: Unique identifier of the element.
     """
 
     def __init__(
         self,
         length: Union[torch.Tensor, nn.Parameter],
-        angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        horizontal_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        # vertical_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         name: Optional[str] = None,
         device=None,
         dtype=torch.float32,
-    ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
-
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.angle = (
-            torch.as_tensor(angle, **factory_kwargs)
-            if angle is not None
-            else torch.zeros_like(self.length)
-        )
-
-    def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
-        device = self.length.device
-        dtype = self.length.dtype
-
-        gamma = energy / electron_mass_eV.to(device=device, dtype=dtype)
-        igamma2 = torch.zeros_like(gamma)  # TODO: Effect on gradients?
-        igamma2[gamma != 0] = 1 / gamma[gamma != 0] ** 2
-        beta = torch.sqrt(1 - igamma2)
-
-        tm = torch.eye(7, device=device, dtype=dtype).repeat((*self.length.shape, 1, 1))
-        tm[..., 0, 1] = self.length
-        tm[..., 1, 6] = self.angle
-        tm[..., 2, 3] = self.length
-        tm[..., 4, 5] = -self.length / beta**2 * igamma2
-
-        return tm
-
-    def broadcast(self, shape: Size) -> Element:
-        return self.__class__(
-            length=self.length.repeat(shape), angle=self.angle, name=self.name
-        )
-
-    @property
-    def is_skippable(self) -> bool:
-        return True
-
-    @property
-    def is_active(self) -> bool:
-        return any(self.angle != 0)
-
-    def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            length = torch.min(resolution, remaining)
-            element = HorizontalCorrector(length, self.angle * length / self.length)
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
-
-    def plot(self, ax: plt.Axes, s: float) -> None:
-        alpha = 1 if self.is_active else 0.2
-        height = 0.8 * (np.sign(self.angle[0]) if self.is_active else 1)
-
-        patch = Rectangle(
-            (s, 0), self.length[0], height, color="tab:blue", alpha=alpha, zorder=2
-        )
-        ax.add_patch(patch)
-
-    @property
-    def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "angle"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"name={repr(self.name)})"
+    ):
+        super().__init__(
+            length=length,
+            horizontal_angle=horizontal_angle,
+            name=name,
+            device=device,
+            dtype=dtype,
         )

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -1,107 +1,39 @@
 from typing import Optional, Union
 
-import matplotlib.pyplot as plt
-import numpy as np
 import torch
-from matplotlib.patches import Rectangle
-from scipy.constants import physical_constants
-from torch import Size, nn
+from torch import nn
 
 from cheetah.utils import UniqueNameGenerator
 
-from .element import Element
+from .corrector import Corrector
 
 generate_unique_name = UniqueNameGenerator(prefix="unnamed_element")
 
-electron_mass_eV = torch.tensor(
-    physical_constants["electron mass energy equivalent in MeV"][0] * 1e6
-)
 
-
-class VerticalCorrector(Element):
+class VerticalCorrector(Corrector):
     """
-    Verticle corrector magnet in a particle accelerator.
+    Vertical corrector magnet in a particle accelerator.
     Note: This is modeled as a drift section with
         a thin-kick in the vertical plane.
 
     :param length: Length in meters.
-    :param angle: Particle deflection angle in the vertical plane in rad.
+    :param vertical_angle: Particle deflection angle in the vertical plane in rad.
     :param name: Unique identifier of the element.
     """
 
     def __init__(
         self,
         length: Union[torch.Tensor, nn.Parameter],
-        angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        # horizontal_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        vertical_angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         name: Optional[str] = None,
         device=None,
         dtype=torch.float32,
-    ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
-
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.angle = (
-            torch.as_tensor(angle, **factory_kwargs)
-            if angle is not None
-            else torch.zeros_like(self.length)
-        )
-
-    def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
-        device = self.length.device
-        dtype = self.length.dtype
-
-        gamma = energy / electron_mass_eV.to(device=device, dtype=dtype)
-        igamma2 = torch.zeros_like(gamma)  # TODO: Effect on gradients?
-        igamma2[gamma != 0] = 1 / gamma[gamma != 0] ** 2
-        beta = torch.sqrt(1 - igamma2)
-
-        tm = torch.eye(7, device=device, dtype=dtype).repeat((*self.length.shape, 1, 1))
-        tm[..., 0, 1] = self.length
-        tm[..., 2, 3] = self.length
-        tm[..., 3, 6] = self.angle
-        tm[..., 4, 5] = -self.length / beta**2 * igamma2
-        return tm
-
-    def broadcast(self, shape: Size) -> Element:
-        return self.__class__(
-            length=self.length.repeat(shape), angle=self.angle, name=self.name
-        )
-
-    @property
-    def is_skippable(self) -> bool:
-        return True
-
-    @property
-    def is_active(self) -> bool:
-        return any(self.angle != 0)
-
-    def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            length = torch.min(resolution, remaining)
-            element = VerticalCorrector(length, self.angle * length / self.length)
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
-
-    def plot(self, ax: plt.Axes, s: float) -> None:
-        alpha = 1 if self.is_active else 0.2
-        height = 0.8 * (np.sign(self.angle[0]) if self.is_active else 1)
-
-        patch = Rectangle(
-            (s, 0), self.length[0], height, color="tab:cyan", alpha=alpha, zorder=2
-        )
-        ax.add_patch(patch)
-
-    @property
-    def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "angle"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"name={repr(self.name)})"
+    ):
+        super().__init__(
+            length=length,
+            vertical_angle=vertical_angle,
+            name=name,
+            device=device,
+            dtype=dtype,
         )

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -1,0 +1,69 @@
+import torch
+
+from cheetah import Corrector, Drift, ParameterBeam, ParticleBeam, Segment
+
+
+def test_corrector_off():
+    """
+    Test that a corrector with horizontal_angle=0 and vertical_angle=0 behaves
+    still like a drift.
+    """
+    corrector = Corrector(
+        length=torch.tensor([0.3]),
+        horizontal_angle=torch.tensor([0.0]),
+        vertical_angle=torch.tensor([0.0]),
+    )
+    drift = Drift(length=torch.tensor([1.0]))
+    incoming_beam = ParameterBeam.from_twiss(
+        energy=torch.tensor([1.8e7]),
+        beta_x=torch.tensor([5]),
+        beta_y=torch.tensor([5]),
+    )
+    outbeam_corrector_off = corrector(incoming_beam)
+    outbeam_drift = drift(incoming_beam)
+
+    corrector.horizontal_angle = torch.tensor(
+        [5.0], device=corrector.horizontal_angle.device
+    )
+    corrector.vertical_angle = torch.tensor(
+        [7.0], device=corrector.vertical_angle.device
+    )
+    outbeam_corrector_on = corrector(incoming_beam)
+
+    print(outbeam_corrector_off)
+    print(outbeam_drift)
+    print(outbeam_corrector_on)
+
+    assert corrector.name is not None
+    assert torch.allclose(outbeam_corrector_off.mu_xp, outbeam_drift.mu_xp)
+    assert torch.allclose(outbeam_corrector_off.mu_yp, outbeam_drift.mu_yp)
+    assert not torch.allclose(outbeam_corrector_on.mu_xp, outbeam_drift.mu_xp)
+    assert not torch.allclose(outbeam_corrector_on.mu_yp, outbeam_drift.mu_yp)
+
+
+def test_corrector_batched_execution():
+    """
+    Test that a corrector with batch dimensions behaves as expected.
+    """
+    batch_shape = torch.Size([3])
+    incoming = ParticleBeam.from_parameters(
+        num_particles=torch.tensor(1000000),
+        energy=torch.tensor([1.8e7]),
+    ).broadcast(batch_shape)
+    segment = Segment(
+        [
+            Corrector(
+                length=torch.tensor([0.04, 0.04, 0.04]),
+                horizontal_angle=torch.tensor([0.001, 0.003, 0.001]),
+                vertical_angle=torch.tensor([0.001, 0.002, 0.001]),
+            ),
+            Drift(length=torch.tensor([0.5])).broadcast(batch_shape),
+        ]
+    )
+    outgoing = segment(incoming)
+
+    # Check that dipole with same bend angle produce same output
+    assert torch.allclose(outgoing.particles[0], outgoing.particles[2])
+
+    # Check different angles do make a difference
+    assert not torch.allclose(outgoing.particles[0], outgoing.particles[1])

--- a/tests/test_correctors.py
+++ b/tests/test_correctors.py
@@ -1,0 +1,72 @@
+import torch
+
+from cheetah import Corrector, Drift, ParameterBeam, ParticleBeam, Segment
+
+
+def test_corrector_off():
+    """
+    Test that a corrector with horizontal_angle=0 and vertical_angle=0 behaves
+    still like a drift.
+    """
+    corrector = Corrector(
+        length=torch.tensor([0.3]),
+        horizontal_angle=torch.tensor([0.0]),
+        vertical_angle=torch.tensor([0.0]),
+    )
+    drift = Drift(length=torch.tensor([1.0]))
+    incoming_beam = ParameterBeam.from_twiss(
+        energy=torch.tensor([1.8e7]),
+        beta_x=torch.tensor([5]),
+        beta_y=torch.tensor([5]),
+    )
+    outbeam_corrector_off = corrector(incoming_beam)
+    outbeam_drift = drift(incoming_beam)
+
+    corrector.horizontal_angle = torch.tensor(
+        [2.0], device=corrector.horizontal_angle.device
+    )
+    corrector.vertical_angle = torch.tensor(
+        [2.0], device=corrector.vertical_angle.device
+    )
+    outbeam_corrector_on = corrector(incoming_beam)
+
+    print(outbeam_corrector_off)
+    print(outbeam_drift)
+    print(outbeam_corrector_on)
+
+    assert corrector.name is not None
+    assert torch.allclose(outbeam_corrector_off.mu_xp, outbeam_drift.mu_xp)
+    assert torch.allclose(outbeam_corrector_off.mu_yp, outbeam_drift.mu_yp)
+    assert not torch.allclose(outbeam_corrector_on.mu_xp, outbeam_drift.mu_xp)
+    assert not torch.allclose(outbeam_corrector_on.mu_yp, outbeam_drift.mu_yp)
+
+
+test_corrector_off()
+
+
+def test_corrector_batched_execution():
+    """
+    Test that a corrector with batch dimensions behaves as expected.
+    """
+    batch_shape = torch.Size([3])
+    incoming = ParticleBeam.from_parameters(
+        num_particles=torch.tensor(1000000),
+        energy=torch.tensor([1.8e7]),
+    ).broadcast(batch_shape)
+    segment = Segment(
+        [
+            Corrector(
+                length=torch.tensor([0.04, 0.04, 0.04]),
+                horizontal_angle=torch.tensor([0.001, 0.003, 0.001]),
+                vertical_angle=torch.tensor([0.001, 0.002, 0.001]),
+            ),
+            Drift(length=torch.tensor([0.5])).broadcast(batch_shape),
+        ]
+    )
+    outgoing = segment(incoming)
+
+    # Check that dipole with same bend angle produce same output
+    assert torch.allclose(outgoing.particles[0], outgoing.particles[2])
+
+    # Check different angles do make a difference
+    assert not torch.allclose(outgoing.particles[0], outgoing.particles[1])

--- a/tests/test_vertical_corrector.py
+++ b/tests/test_vertical_corrector.py
@@ -1,0 +1,100 @@
+import torch
+
+from cheetah import Drift, ParameterBeam, ParticleBeam, Segment, VerticalCorrector
+
+
+def test_vertical_corrector_off():
+    """
+    Test that a corrector with vertical_angle=0 behaves
+    still like a drift and that the angle translates properly.
+    """
+    corrector = VerticalCorrector(
+        length=torch.tensor([0.3]),
+        vertical_angle=torch.tensor([0.0]),
+    )
+    drift = Drift(length=torch.tensor([1.0]))
+    incoming_beam = ParameterBeam.from_twiss(
+        energy=torch.tensor([1.8e7]),
+        beta_x=torch.tensor([5]),
+        beta_y=torch.tensor([5]),
+    )
+    outbeam_corrector_off = corrector(incoming_beam)
+    outbeam_drift = drift(incoming_beam)
+
+    corrector.vertical_angle = torch.tensor(
+        [7.0], device=corrector.horizontal_angle.device
+    )
+    outbeam_corrector_on = corrector(incoming_beam)
+
+    assert corrector.name is not None
+    assert torch.allclose(outbeam_corrector_off.mu_yp, outbeam_drift.mu_yp)
+    assert torch.allclose(outbeam_corrector_on.mu_xp, outbeam_drift.mu_xp)
+    assert torch.allclose(outbeam_corrector_on.mu_yp, corrector.vertical_angle)
+    assert not torch.allclose(outbeam_corrector_on.mu_yp, outbeam_drift.mu_yp)
+
+
+def test_vertical_angle_only():
+    """
+    Test that the vertical corrector behaves as expected.
+    """
+    try:
+        VerticalCorrector(
+            length=torch.tensor([0.3]),
+            vertical_angle=torch.tensor([5.0]),
+            horizontal_angle=torch.tensor([7.0]),
+        )
+    except TypeError:
+        assert True
+
+    try:
+        VerticalCorrector(
+            length=torch.tensor([0.3]),
+            vertical_angle=torch.tensor([5.0]),
+        )
+    except TypeError:
+        assert False
+
+    try:
+        corrector = VerticalCorrector(
+            length=torch.tensor([0.3]),
+            vertical_angle=torch.tensor([5.0]),
+        )
+        print(corrector.vertical_angle)
+    except TypeError:
+        assert False
+
+    try:
+        corrector = VerticalCorrector(
+            length=torch.tensor([0.3]),
+            vertical_angle=torch.tensor([5.0]),
+        )
+        print(corrector.horizontal_angle)
+    except TypeError:
+        assert True
+
+
+def test_corrector_batched_execution():
+    """
+    Test that a corrector with batch dimensions behaves as expected.
+    """
+    batch_shape = torch.Size([3])
+    incoming = ParticleBeam.from_parameters(
+        num_particles=torch.tensor(1000000),
+        energy=torch.tensor([1.8e7]),
+    ).broadcast(batch_shape)
+    segment = Segment(
+        [
+            VerticalCorrector(
+                length=torch.tensor([0.04, 0.04, 0.04]),
+                vertical_angle=torch.tensor([0.001, 0.003, 0.001]),
+            ),
+            Drift(length=torch.tensor([0.5])).broadcast(batch_shape),
+        ]
+    )
+    outgoing = segment(incoming)
+
+    # Check that dipole with same bend angle produce same output
+    assert torch.allclose(outgoing.particles[0], outgoing.particles[2])
+
+    # Check different angles do make a difference
+    assert not torch.allclose(outgoing.particles[0], outgoing.particles[1])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Implementation of a new class `Corrector`. 
To build the `Corrector` class I took the old `HorizontalCorrector` class and added an extra entry in the transfer matrix to include `yp` (vertical angle). Now instead of the `angle` property, you have `horizontal_angle` and `vertical_angle`.
- `xp` is in position (1,6) 
- `yp` is in position (3,6)

I then derived `HorizontalCorrector` and `VerticalCorrector` from the `Corrector` class, and removed either `vertical_angle` or `horizontal_angle` as property. This is checked in the corresponding test scripts (e.g. one cannot feed the `horizontal_angle` property to `VerticalCorrector`).

One could make it in a way that `HorizontalCorrector` and `VerticalCorrector` both have the `angle` property, but I don't know how to do that and the current solution works.

## Motivation and Context

The motivation is because I need it to continue with the MAD-X converter, using the AWAKE lattice which contains combined correctors. Probably also useful to other people in the future.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
Closes issue #203 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [x] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
