### PR TITLE
Implement moving to `device` and changing `dtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add Python 3.12 support (see #161) (@jank324)
 - Implement space charge using Green's function in a `SpaceChargeKick` element (see #142) (@greglenerd, @RemiLehe, @ax3l, @cr-xu, @jank324)
 - `Segment`s can now be imported from Bmad to devices other than `torch.device("cpu")` and dtypes other than `torch.float32` (see #196, #206) (@jank324)
+- Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/aperture.py
+++ b/cheetah/accelerator/aperture.py
@@ -37,15 +37,21 @@ class Aperture(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.x_max = (
-            torch.as_tensor(x_max, **factory_kwargs)
-            if x_max is not None
-            else torch.tensor(float("inf"), **factory_kwargs)
+        self.register_buffer(
+            "x_max",
+            (
+                torch.as_tensor(x_max, **factory_kwargs)
+                if x_max is not None
+                else torch.tensor(float("inf"), **factory_kwargs)
+            ),
         )
-        self.y_max = (
-            torch.as_tensor(y_max, **factory_kwargs)
-            if y_max is not None
-            else torch.tensor(float("inf"), **factory_kwargs)
+        self.register_buffer(
+            "y_max",
+            (
+                torch.as_tensor(y_max, **factory_kwargs)
+                if y_max is not None
+                else torch.tensor(float("inf"), **factory_kwargs)
+            ),
         )
         self.shape = shape
         self.is_active = is_active

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -43,21 +43,30 @@ class Cavity(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.voltage = (
-            torch.as_tensor(voltage, **factory_kwargs)
-            if voltage is not None
-            else torch.tensor(0.0, **factory_kwargs)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "voltage",
+            (
+                torch.as_tensor(voltage, **factory_kwargs)
+                if voltage is not None
+                else torch.tensor(0.0, **factory_kwargs)
+            ),
         )
-        self.phase = (
-            torch.as_tensor(phase, **factory_kwargs)
-            if phase is not None
-            else torch.tensor(0.0, **factory_kwargs)
+        self.register_buffer(
+            "phase",
+            (
+                torch.as_tensor(phase, **factory_kwargs)
+                if phase is not None
+                else torch.tensor(0.0, **factory_kwargs)
+            ),
         )
-        self.frequency = (
-            torch.as_tensor(frequency, **factory_kwargs)
-            if frequency is not None
-            else torch.tensor(0.0, **factory_kwargs)
+        self.register_buffer(
+            "frequency",
+            (
+                torch.as_tensor(frequency, **factory_kwargs)
+                if frequency is not None
+                else torch.tensor(0.0, **factory_kwargs)
+            ),
         )
 
     @property

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -31,11 +31,16 @@ class CustomTransferMap(Element):
         assert isinstance(transfer_map, torch.Tensor)
         assert transfer_map.shape[-2:] == (7, 7)
 
-        self._transfer_map = torch.as_tensor(transfer_map, **factory_kwargs)
-        self.length = (
-            torch.as_tensor(length, **factory_kwargs)
-            if length is not None
-            else torch.zeros(transfer_map.shape[:-2], **factory_kwargs)
+        self.register_buffer(
+            "_transfer_map", torch.as_tensor(transfer_map, **factory_kwargs)
+        )
+        self.register_buffer(
+            "length",
+            (
+                torch.as_tensor(length, **factory_kwargs)
+                if length is not None
+                else torch.zeros(transfer_map.shape[:-2], **factory_kwargs)
+            ),
         )
 
     @classmethod

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -47,42 +47,63 @@ class Dipole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.angle = (
-            torch.as_tensor(angle, **factory_kwargs)
-            if angle is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "angle",
+            (
+                torch.as_tensor(angle, **factory_kwargs)
+                if angle is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.gap = (
-            torch.as_tensor(gap, **factory_kwargs)
-            if gap is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "gap",
+            (
+                torch.as_tensor(gap, **factory_kwargs)
+                if gap is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.tilt = (
-            torch.as_tensor(tilt, **factory_kwargs)
-            if tilt is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "tilt",
+            (
+                torch.as_tensor(tilt, **factory_kwargs)
+                if tilt is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.fringe_integral = (
-            torch.as_tensor(fringe_integral, **factory_kwargs)
-            if fringe_integral is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "fringe_integral",
+            (
+                torch.as_tensor(fringe_integral, **factory_kwargs)
+                if fringe_integral is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.fringe_integral_exit = (
-            self.fringe_integral
-            if fringe_integral_exit is None
-            else torch.as_tensor(fringe_integral_exit, **factory_kwargs)
+        self.register_buffer(
+            "fringe_integral_exit",
+            (
+                self.fringe_integral
+                if fringe_integral_exit is None
+                else torch.as_tensor(fringe_integral_exit, **factory_kwargs)
+            ),
         )
         # Sector bend if not specified
-        self.e1 = (
-            torch.as_tensor(e1, **factory_kwargs)
-            if e1 is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "e1",
+            (
+                torch.as_tensor(e1, **factory_kwargs)
+                if e1 is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.e2 = (
-            torch.as_tensor(e2, **factory_kwargs)
-            if e2 is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "e2",
+            (
+                torch.as_tensor(e2, **factory_kwargs)
+                if e2 is not None
+                else torch.zeros_like(self.length)
+            ),
         )
 
     @property

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -37,7 +37,7 @@ class Drift(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         assert (

--- a/cheetah/accelerator/element.py
+++ b/cheetah/accelerator/element.py
@@ -22,6 +22,7 @@ class Element(ABC, nn.Module):
         super().__init__()
 
         self.name = name if name is not None else generate_unique_name()
+        self.register_buffer("length", torch.zeros((1,)))
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         r"""

--- a/cheetah/accelerator/element.py
+++ b/cheetah/accelerator/element.py
@@ -18,8 +18,6 @@ class Element(ABC, nn.Module):
     :param name: Unique identifier of the element.
     """
 
-    length: torch.Tensor = torch.zeros((1))
-
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__()
 

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -40,11 +40,14 @@ class HorizontalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.angle = (
-            torch.as_tensor(angle, **factory_kwargs)
-            if angle is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "angle",
+            (
+                torch.as_tensor(angle, **factory_kwargs)
+                if angle is not None
+                else torch.zeros_like(self.length)
+            ),
         )
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -39,21 +39,30 @@ class Quadrupole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.k1 = (
-            torch.as_tensor(k1, **factory_kwargs)
-            if k1 is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "k1",
+            (
+                torch.as_tensor(k1, **factory_kwargs)
+                if k1 is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.misalignment = (
-            torch.as_tensor(misalignment, **factory_kwargs)
-            if misalignment is not None
-            else torch.zeros((*self.length.shape, 2), **factory_kwargs)
+        self.register_buffer(
+            "misalignment",
+            (
+                torch.as_tensor(misalignment, **factory_kwargs)
+                if misalignment is not None
+                else torch.zeros((*self.length.shape, 2), **factory_kwargs)
+            ),
         )
-        self.tilt = (
-            torch.as_tensor(tilt, **factory_kwargs)
-            if tilt is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer(
+            "tilt",
+            (
+                torch.as_tensor(tilt, **factory_kwargs)
+                if tilt is not None
+                else torch.zeros_like(self.length)
+            ),
         )
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -46,27 +46,42 @@ class Screen(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.resolution = (
-            torch.as_tensor(resolution, device=device)
-            if resolution is not None
-            else torch.tensor((1024, 1024), device=device)
+        self.register_buffer(
+            "resolution",
+            (
+                torch.as_tensor(resolution, **factory_kwargs)
+                if resolution is not None
+                else torch.tensor((1024, 1024), **factory_kwargs)
+            ),
         )
-        self.pixel_size = (
-            torch.as_tensor(pixel_size, **factory_kwargs)
-            if pixel_size is not None
-            else torch.tensor((1e-3, 1e-3), **factory_kwargs)
+        self.register_buffer(
+            "pixel_size",
+            (
+                torch.as_tensor(pixel_size, **factory_kwargs)
+                if pixel_size is not None
+                else torch.tensor((1e-3, 1e-3), **factory_kwargs)
+            ),
         )
-        self.binning = (
-            torch.as_tensor(binning, device=device)
-            if binning is not None
-            else torch.tensor(1, device=device)
+        self.register_buffer(
+            "binning",
+            (
+                torch.as_tensor(binning, **factory_kwargs)
+                if binning is not None
+                else torch.tensor(1, **factory_kwargs)
+            ),
         )
-        self.misalignment = (
-            torch.as_tensor(misalignment, **factory_kwargs)
-            if misalignment is not None
-            else torch.tensor([(0.0, 0.0)], **factory_kwargs)
+        self.register_buffer(
+            "misalignment",
+            (
+                torch.as_tensor(misalignment, **factory_kwargs)
+                if misalignment is not None
+                else torch.tensor([(0.0, 0.0)], **factory_kwargs)
+            ),
         )
-        self.length = torch.zeros(self.misalignment.shape[:-1], **factory_kwargs)
+        self.register_buffer(
+            "length",
+            torch.zeros(self.misalignment.shape[:-1], **factory_kwargs),
+        )
         self.is_active = is_active
 
         self.set_read_beam(None)

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -44,16 +44,22 @@ class Solenoid(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.k = (
-            torch.as_tensor(k, **factory_kwargs)
-            if k is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "k",
+            (
+                torch.as_tensor(k, **factory_kwargs)
+                if k is not None
+                else torch.zeros_like(self.length)
+            ),
         )
-        self.misalignment = (
-            torch.as_tensor(misalignment, **factory_kwargs)
-            if misalignment is not None
-            else torch.zeros((*self.length.shape[:-1], 2), **factory_kwargs)
+        self.register_buffer(
+            "misalignment",
+            (
+                torch.as_tensor(misalignment, **factory_kwargs)
+                if misalignment is not None
+                else torch.zeros((*self.length.shape[:-1], 2), **factory_kwargs)
+            ),
         )
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -68,16 +68,24 @@ class SpaceChargeKick(Element):
 
         super().__init__(name=name)
 
-        self.effect_length = torch.as_tensor(effect_length, **self.factory_kwargs)
+        self.register_buffer(
+            "effect_length", torch.as_tensor(effect_length, **self.factory_kwargs)
+        )
         self.grid_shape = (
             int(num_grid_points_x),
             int(num_grid_points_y),
             int(num_grid_points_s),
         )
         # In multiples of sigma
-        self.grid_extend_x = torch.as_tensor(grid_extend_x, **self.factory_kwargs)
-        self.grid_extend_y = torch.as_tensor(grid_extend_y, **self.factory_kwargs)
-        self.grid_extend_s = torch.as_tensor(grid_extend_s, **self.factory_kwargs)
+        self.register_buffer(
+            "grid_extend_x", torch.as_tensor(grid_extend_x, **self.factory_kwargs)
+        )
+        self.register_buffer(
+            "grid_extend_y", torch.as_tensor(grid_extend_y, **self.factory_kwargs)
+        )
+        self.register_buffer(
+            "grid_extend_s", torch.as_tensor(grid_extend_s, **self.factory_kwargs)
+        )
 
     def _deposit_charge_on_grid(
         self,

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -40,7 +40,7 @@ class Undulator(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
         self.is_active = is_active
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -40,11 +40,14 @@ class VerticalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.length = torch.as_tensor(length, **factory_kwargs)
-        self.angle = (
-            torch.as_tensor(angle, **factory_kwargs)
-            if angle is not None
-            else torch.zeros_like(self.length)
+        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer(
+            "angle",
+            (
+                torch.as_tensor(angle, **factory_kwargs)
+                if angle is not None
+                else torch.zeros_like(self.length)
+            ),
         )
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -30,15 +30,17 @@ class ParameterBeam(Beam):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
 
-        self._mu = torch.as_tensor(mu, **factory_kwargs)
-        self._cov = torch.as_tensor(cov, **factory_kwargs)
+        self.register_buffer("_mu", torch.as_tensor(mu, **factory_kwargs))
+        self.register_buffer("_cov", torch.as_tensor(cov, **factory_kwargs))
         total_charge = (
             total_charge
             if total_charge is not None
             else torch.tensor([0.0], **factory_kwargs)
         )
-        self.total_charge = torch.as_tensor(total_charge, **factory_kwargs)
-        self.energy = torch.as_tensor(energy, **factory_kwargs)
+        self.register_buffer(
+            "total_charge", torch.as_tensor(total_charge, **factory_kwargs)
+        )
+        self.register_buffer("energy", torch.as_tensor(energy, **factory_kwargs))
 
     @classmethod
     def from_parameters(

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -36,13 +36,16 @@ class ParticleBeam(Beam):
             particles.shape[-2] > 0 and particles.shape[-1] == 7
         ), "Particle vectors must be 7-dimensional."
 
-        self.particles = particles.to(**factory_kwargs)
-        self.particle_charges = (
-            particle_charges.to(**factory_kwargs)
-            if particle_charges is not None
-            else torch.zeros(particles.shape[:2], **factory_kwargs)
+        self.register_buffer("particles", particles.to(**factory_kwargs))
+        self.register_buffer(
+            "particle_charges",
+            (
+                particle_charges.to(**factory_kwargs)
+                if particle_charges is not None
+                else torch.zeros(particles.shape[:2], **factory_kwargs)
+            ),
         )
-        self.energy = energy.to(**factory_kwargs)
+        self.register_buffer("energy", energy.to(**factory_kwargs))
 
     @classmethod
     def from_parameters(

--- a/tests/test_device_dtype.py
+++ b/tests/test_device_dtype.py
@@ -65,3 +65,56 @@ def test_change_quadrupole_dtype():
     assert quad.k1.dtype == torch.float64
     assert quad.misalignment.dtype == torch.float64
     assert quad.tilt.dtype == torch.float64
+
+
+@pytest.mark.parametrize(
+    "target_device",
+    [
+        pytest.param(
+            torch.device("cuda"),
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA not available"
+            ),
+        ),
+        pytest.param(
+            torch.device("mps"),
+            marks=pytest.mark.skipif(
+                not torch.backends.mps.is_available(), reason="MPS not available"
+            ),
+        ),
+    ],
+)
+def test_move_particlebeam_to_device(target_device: torch.device):
+    """Test that a particle beam can be successfully moved to a different device."""
+    beam = cheetah.ParticleBeam.from_parameters(num_particles=100_000)
+
+    # Test that by default the particle beam is on the CPU
+    assert beam.particles.device.type == "cpu"
+    assert beam.energy.device.type == "cpu"
+    assert beam.total_charge.device.type == "cpu"
+
+    beam.to(target_device)
+
+    # Test that the particle beam is now on the target device
+    assert beam.particles.device.type == target_device.type
+    assert beam.energy.device.type == target_device.type
+    assert beam.total_charge.device.type == target_device.type
+
+
+def test_change_particlebeam_dtype():
+    """
+    Test that a particle beam can be successfully changed to a different dtype.
+    """
+    beam = cheetah.ParticleBeam.from_parameters(num_particles=100_000)
+
+    # Test that by default the particle beam is of dtype float32
+    assert beam.particles.dtype == torch.float32
+    assert beam.energy.dtype == torch.float32
+    assert beam.total_charge.dtype == torch.float32
+
+    beam.to(torch.float64)
+
+    # Test that the particle beam is now of dtype float64
+    assert beam.particles.dtype == torch.float64
+    assert beam.energy.dtype == torch.float64
+    assert beam.total_charge.dtype == torch.float64

--- a/tests/test_device_dtype.py
+++ b/tests/test_device_dtype.py
@@ -28,7 +28,6 @@ def test_move_quadrupole_to_device(target_device: torch.device):
     )
 
     # Test that by default the quadrupole is on the CPU
-    assert quad.device.type == "cpu"
     assert quad.length.device.type == "cpu"
     assert quad.k1.device.type == "cpu"
     assert quad.misalignment.device.type == "cpu"
@@ -38,7 +37,6 @@ def test_move_quadrupole_to_device(target_device: torch.device):
     quad.to(target_device)
 
     # Test that the quadrupole is now on the target device
-    assert quad.device.type == target_device.type
     assert quad.length.device.type == target_device.type
     assert quad.k1.device.type == target_device.type
     assert quad.misalignment.device.type == target_device.type
@@ -52,7 +50,6 @@ def test_change_quadrupole_dtype():
     )
 
     # Test that by default the quadrupole is of dtype float32
-    assert quad.dtype == torch.float32
     assert quad.length.dtype == torch.float32
     assert quad.k1.dtype == torch.float32
     assert quad.misalignment.dtype == torch.float32
@@ -62,7 +59,6 @@ def test_change_quadrupole_dtype():
     quad.to(torch.float64)
 
     # Test that the quadrupole is now of dtype float64
-    assert quad.dtype == torch.float64
     assert quad.length.dtype == torch.float64
     assert quad.k1.dtype == torch.float64
     assert quad.misalignment.dtype == torch.float64

--- a/tests/test_device_dtype.py
+++ b/tests/test_device_dtype.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+
+import cheetah
+
+
+@pytest.mark.parametrize(
+    "target_device",
+    [
+        pytest.param(
+            torch.device("cuda"),
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA not available"
+            ),
+        ),
+        pytest.param(
+            torch.device("mps"),
+            marks=pytest.mark.skipif(
+                not torch.backends.mps.is_available(), reason="MPS not available"
+            ),
+        ),
+    ],
+)
+def test_move_quadrupole_to_device(target_device: torch.device):
+    """Test that a quadrupole magnet can be successfully moved to a different device."""
+    quad = cheetah.Quadrupole(
+        length=torch.tensor([0.2]), k1=torch.tensor([4.2]), name="my_quad"
+    )
+
+    # Test that by default the quadrupole is on the CPU
+    assert quad.device.type == "cpu"
+    assert quad.length.device.type == "cpu"
+    assert quad.k1.device.type == "cpu"
+    assert quad.misalignment.device.type == "cpu"
+    assert quad.tilt.device.type == "cpu"
+
+    # Move the quadrupole to the target device
+    quad.to(target_device)
+
+    # Test that the quadrupole is now on the target device
+    assert quad.device.type == target_device.type
+    assert quad.length.device.type == target_device.type
+    assert quad.k1.device.type == target_device.type
+    assert quad.misalignment.device.type == target_device.type
+    assert quad.tilt.device.type == target_device.type
+
+
+def test_change_quadrupole_dtype():
+    """Test that a quadrupole magnet can be successfully changed to a different dtype."""
+    quad = cheetah.Quadrupole(
+        length=torch.tensor([0.2]), k1=torch.tensor([4.2]), name="my_quad"
+    )
+
+    # Test that by default the quadrupole is of dtype float32
+    assert quad.dtype == torch.float32
+    assert quad.length.dtype == torch.float32
+    assert quad.k1.dtype == torch.float32
+    assert quad.misalignment.dtype == torch.float32
+    assert quad.tilt.dtype == torch.float32
+
+    # Change the dtype of the quadrupole
+    quad.to(torch.float64)
+
+    # Test that the quadrupole is now of dtype float64
+    assert quad.dtype == torch.float64
+    assert quad.length.dtype == torch.float64
+    assert quad.k1.dtype == torch.float64
+    assert quad.misalignment.dtype == torch.float64
+    assert quad.tilt.dtype == torch.float64

--- a/tests/test_device_dtype.py
+++ b/tests/test_device_dtype.py
@@ -44,7 +44,9 @@ def test_move_quadrupole_to_device(target_device: torch.device):
 
 
 def test_change_quadrupole_dtype():
-    """Test that a quadrupole magnet can be successfully changed to a different dtype."""
+    """
+    Test that a quadrupole magnet can be successfully changed to a different dtype.
+    """
     quad = cheetah.Quadrupole(
         length=torch.tensor([0.2]), k1=torch.tensor([4.2]), name="my_quad"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Implements that elements and beams can easily be moved to different devices and their beam types can be changes, like you would expect from a normal `torch.nn.Module`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

This is normal for `torch.nn.Module` and would make working with different devices and dtypes in Cheetah much easier. Closes #113.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
