### PR TITLE
Fix `dtype` preservation on `split`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add `name` to `Drift` element `__repr__` (see #201) (@ansantam)
 - Fix bug where `dtype` was not used when creating a `ParameterBeam` from Twiss parameters (see #206) (@jank324)
 - Fix bug after running `Segment.inactive_elements_as_drifts` the drifts could have the wrong `dtype` (see #206) (@jank324)
+- Fix an issue where splitting elements would result in splits with a different `dtype` (see #211) (@jank324)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -70,7 +70,11 @@ class Drift(Element):
         split_elements = []
         remaining = self.length
         while remaining > 0:
-            element = Drift(torch.min(resolution, remaining))
+            element = Drift(
+                torch.min(resolution, remaining),
+                dtype=self.length.dtype,
+                device=self.length.device,
+            )
             split_elements.append(element)
             remaining -= resolution
         return split_elements

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -82,7 +82,12 @@ class HorizontalCorrector(Element):
         remaining = self.length
         while remaining > 0:
             length = torch.min(resolution, remaining)
-            element = HorizontalCorrector(length, self.angle * length / self.length)
+            element = HorizontalCorrector(
+                length,
+                self.angle * length / self.length,
+                dtype=self.length.dtype,
+                device=self.length.device,
+            )
             split_elements.append(element)
             remaining -= resolution
         return split_elements

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -97,6 +97,9 @@ class Quadrupole(Element):
                 torch.min(resolution, remaining),
                 self.k1,
                 misalignment=self.misalignment,
+                tilt=self.tilt,
+                dtype=self.length.dtype,
+                device=self.length.device,
             )
             split_elements.append(element)
             remaining -= resolution

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -433,7 +433,16 @@ class Segment(Element):
                 sigma_s=beam.sigma_s,
                 sigma_p=beam.sigma_p,
                 energy=beam.energy,
-                device="cpu",
+                dtype=(
+                    beam.particles.dtype
+                    if isinstance(beam, ParticleBeam)
+                    else beam._mu.dtype
+                ),
+                device=(
+                    beam.particles.device
+                    if isinstance(beam, ParticleBeam)
+                    else beam._mu.device
+                ),
             )
             references.append(initial)
         for split in splits:

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -81,7 +81,12 @@ class VerticalCorrector(Element):
         remaining = self.length
         while remaining > 0:
             length = torch.min(resolution, remaining)
-            element = VerticalCorrector(length, self.angle * length / self.length)
+            element = VerticalCorrector(
+                length,
+                self.angle * length / self.length,
+                device=self.length.device,
+                dtype=self.length.dtype,
+            )
             split_elements.append(element)
             remaining -= resolution
         return split_elements

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -196,13 +196,14 @@ def test_vertical_corrector_end():
 @pytest.mark.parametrize(
     "ElementType",
     [
-        cheetah.Drift,
-        cheetah.Quadrupole,
         cheetah.Cavity,
-        cheetah.Solenoid,
         cheetah.Dipole,
-        cheetah.Undulator,
+        cheetah.Drift,
         cheetah.HorizontalCorrector,
+        cheetah.Quadrupole,
+        cheetah.RBend,
+        cheetah.Solenoid,
+        cheetah.Undulator,
         cheetah.VerticalCorrector,
     ],
 )

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -191,3 +191,27 @@ def test_vertical_corrector_end():
     assert torch.allclose(
         outgoing_beam_original.particles, outgoing_beam_split.particles
     )
+
+
+@pytest.mark.parametrize(
+    "ElementType",
+    [
+        cheetah.Drift,
+        cheetah.Quadrupole,
+        cheetah.Cavity,
+        cheetah.Solenoid,
+        cheetah.Dipole,
+        cheetah.Undulator,
+        cheetah.HorizontalCorrector,
+        cheetah.VerticalCorrector,
+    ],
+)
+def test_split_preserves_dtype(ElementType):
+    """
+    Test that the dtype of a drift section's splits is the same as the original drift.
+    """
+    original = ElementType(length=torch.tensor([2.0]), dtype=torch.float64)
+    splits = original.split(resolution=torch.tensor(0.1))
+
+    for split in splits:
+        assert original.length.dtype == split.length.dtype


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Makes sure that when calling `split` on an `Element`, the resulting splits have the same `dtype` as the original `Element`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

This solves an issue when using `Segment.plot_overview` with elements or incoming beams that are not `torch.float32`.

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
