### PR TITLE
Fix `Cavity` being broken by vectorisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚨 Breaking Changes
 
-- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198) (@jank324, @cr-xu)
+- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198, #215) (@jank324, @cr-xu)
 
 ### 🚀 Features
 

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -8,6 +8,7 @@ from scipy.constants import physical_constants
 from torch import Size, nn
 
 from cheetah.particles import Beam, ParameterBeam, ParticleBeam
+from cheetah.track_methods import base_rmatrix
 from cheetah.utils import UniqueNameGenerator
 
 from .element import Element
@@ -82,7 +83,17 @@ class Cavity(Element):
         # was only computed for the elements with voltage > 0 and a basermatrix was
         # used otherwise. This was removed because it was causing issues with the
         # vectorisation, but I am not sure it is okay to remove.
-        tm = self._cavity_rmatrix(energy)
+        tm = torch.where(
+            self.voltage != 0,
+            self._cavity_rmatrix(energy),
+            base_rmatrix(
+                length=self.length,
+                k1=torch.zeros_like(self.length),
+                hx=torch.zeros_like(self.length),
+                tilt=torch.zeros_like(self.length),
+                energy=energy,
+            ),
+        )
 
         return tm
 

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -2,7 +2,6 @@ from typing import Optional, Union
 
 import matplotlib.pyplot as plt
 import torch
-from icecream import ic
 from matplotlib.patches import Rectangle
 from scipy import constants
 from scipy.constants import physical_constants

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 import matplotlib.pyplot as plt
 import torch
+from icecream import ic
 from matplotlib.patches import Rectangle
 from scipy import constants
 from scipy.constants import physical_constants
@@ -79,12 +80,8 @@ class Cavity(Element):
         return not self.is_active
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
-        # There used to be a check for voltage > 0 here, where the cavity transfer map
-        # was only computed for the elements with voltage > 0 and a basermatrix was
-        # used otherwise. This was removed because it was causing issues with the
-        # vectorisation, but I am not sure it is okay to remove.
-        tm = torch.where(
-            self.voltage != 0,
+        return torch.where(
+            (self.voltage != 0).unsqueeze(-1).unsqueeze(-1),
             self._cavity_rmatrix(energy),
             base_rmatrix(
                 length=self.length,
@@ -94,8 +91,6 @@ class Cavity(Element):
                 energy=energy,
             ),
         )
-
-        return tm
 
     def track(self, incoming: Beam) -> Beam:
         """

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -1,4 +1,5 @@
 import torch
+from icecream import ic
 
 import cheetah
 
@@ -29,3 +30,41 @@ def test_assert_ei_greater_zero():
     ).broadcast((3,))
 
     _ = cavity.track(beam)
+
+
+def test_cavity_producing_nan():
+    """
+    Describe later from LCLS.
+    """
+    cavity = cheetah.Cavity(
+        length=torch.tensor([3.0441]),
+        voltage=torch.tensor([0.0]),
+        phase=torch.tensor([-0.0]),
+        frequency=torch.tensor([2.8560e09]),
+        name="k27_1a",
+        dtype=torch.float64,
+    )
+    incoming = cheetah.ParameterBeam.from_parameters(
+        mu_x=torch.tensor([0.0]),
+        mu_xp=torch.tensor([0.0]),
+        mu_y=torch.tensor([0.0]),
+        mu_yp=torch.tensor([0.0]),
+        sigma_x=torch.tensor([4.8492e-06]),
+        sigma_xp=torch.tensor([1.5603e-07]),
+        sigma_y=torch.tensor([4.1209e-07]),
+        sigma_yp=torch.tensor([1.1035e-08]),
+        sigma_s=torch.tensor([1.0000e-10]),
+        sigma_p=torch.tensor([1.0000e-06]),
+        energy=torch.tensor([8.0000e09]),
+        total_charge=torch.tensor([0.0]),
+        dtype=torch.float64,
+    )
+
+    outgoing = cavity.track(incoming)
+
+    ic(outgoing, outgoing._mu, outgoing._cov, incoming._mu, incoming._cov)
+
+    assert not torch.isnan(outgoing.sigma_x).any()
+    assert not torch.isnan(outgoing.sigma_y).any()
+    assert not torch.isnan(outgoing.beta_x).any()
+    assert not torch.isnan(outgoing.beta_y).any()

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -1,5 +1,4 @@
 import torch
-from icecream import ic
 
 import cheetah
 
@@ -32,9 +31,12 @@ def test_assert_ei_greater_zero():
     _ = cavity.track(beam)
 
 
-def test_cavity_producing_nan():
+def test_vectorized_cavity_zero_voltage():
     """
-    Describe later from LCLS.
+    Tests that a vectorised cavity with zero voltage does not produce NaNs. This was a
+    bug introduced during the vectorisation of Cheetah, when the special case of zero
+    was removed and the `_cavity_rmatrix` method was also used in the case of zero
+    voltage. The latter produced NaNs in the transfer matrix when the voltage is zero.
     """
     cavity = cheetah.Cavity(
         length=torch.tensor([3.0441]),
@@ -62,7 +64,7 @@ def test_cavity_producing_nan():
 
     outgoing = cavity.track(incoming)
 
-    ic(outgoing, outgoing._mu, outgoing._cov, incoming._mu, incoming._cov)
+    assert not torch.isnan(cavity.transfer_map(incoming.energy)).any()
 
     assert not torch.isnan(outgoing.sigma_x).any()
     assert not torch.isnan(outgoing.sigma_y).any()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Re-adds the use of `base_rmatrix` for `Cavity`s with `voltage=0.0` because the usually cavity matrix breaks in that case. This was originally removed with the vectorisation because it was difficult to integrate and though to be unnecessary.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Closes #214.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
