### PR TITLE
Let broadcast keep the dtype and device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚨 Breaking Changes
 
-- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198) (@jank324, @cr-xu)
+- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198, #218) (@jank324, @cr-xu)
 
 ### 🚀 Features
 
@@ -25,7 +25,6 @@
 - Fix bug where `dtype` was not used when creating a `ParameterBeam` from Twiss parameters (see #206) (@jank324)
 - Fix bug after running `Segment.inactive_elements_as_drifts` the drifts could have the wrong `dtype` (see #206) (@jank324)
 - Fix an issue where splitting elements would result in splits with a different `dtype` (see #211) (@jank324)
-- Fix an issue where the `dtype` and `device` are set back to default when broadcasting elements or beams. (see #218) (@cr-xu)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix bug where `dtype` was not used when creating a `ParameterBeam` from Twiss parameters (see #206) (@jank324)
 - Fix bug after running `Segment.inactive_elements_as_drifts` the drifts could have the wrong `dtype` (see #206) (@jank324)
 - Fix an issue where splitting elements would result in splits with a different `dtype` (see #211) (@jank324)
+- Fix an issue where the `dtype` and `device` are set back to default when broadcasting elements or beams. (see #218) (@cr-xu)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/aperture.py
+++ b/cheetah/accelerator/aperture.py
@@ -117,6 +117,8 @@ class Aperture(Element):
             shape=self.shape,
             is_active=self.is_active,
             name=self.name,
+            device=self.x_max.device,
+            dtype=self.x_max.dtype,
         )
         new_aperture.length = self.length.repeat(shape)
         return new_aperture

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -345,6 +345,8 @@ class Cavity(Element):
             phase=self.phase.repeat(shape),
             frequency=self.frequency.repeat(shape),
             name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     def split(self, resolution: torch.Tensor) -> list[Element]:

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -90,6 +90,8 @@ class CustomTransferMap(Element):
             self._transfer_map.repeat((*shape, 1, 1)),
             length=self.length.repeat(shape),
             name=self.name,
+            device=self._transfer_map.device,
+            dtype=self._transfer_map.dtype,
         )
 
     @property

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -204,6 +204,8 @@ class Dipole(Element):
             fringe_integral_exit=self.fringe_integral_exit.repeat(shape),
             gap=self.gap.repeat(shape),
             name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     def split(self, resolution: torch.Tensor) -> list[Element]:

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -60,7 +60,12 @@ class Drift(Element):
         return tm
 
     def broadcast(self, shape: Size) -> Element:
-        return self.__class__(length=self.length.repeat(shape), name=self.name)
+        return self.__class__(
+            length=self.length.repeat(shape),
+            name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
+        )
 
     @property
     def is_skippable(self) -> bool:

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -69,7 +69,11 @@ class HorizontalCorrector(Element):
 
     def broadcast(self, shape: Size) -> Element:
         return self.__class__(
-            length=self.length.repeat(shape), angle=self.angle, name=self.name
+            length=self.length.repeat(shape),
+            angle=self.angle,
+            name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     @property

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -88,6 +88,8 @@ class Quadrupole(Element):
             misalignment=self.misalignment.repeat((*shape, 1)),
             tilt=self.tilt.repeat(shape),
             name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     @property

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -289,6 +289,8 @@ class Screen(Element):
             misalignment=self.misalignment.repeat((*shape, 1)),
             is_active=self.is_active,
             name=self.name,
+            device=self.resolution.device,
+            dtype=self.resolution.dtype,
         )
         new_screen.length = self.length.repeat(shape)
         return new_screen

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -114,6 +114,8 @@ class Solenoid(Element):
             k=self.k.repeat(shape),
             misalignment=self.misalignment.repeat(shape),
             name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     @property

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -624,6 +624,8 @@ class SpaceChargeKick(Element):
             grid_extend_y=self.grid_extend_y,
             grid_extend_s=self.grid_extend_s,
             name=self.name,
+            device=self.effect_length.device,
+            dtype=self.effect_length.dtype,
         )
         new_space_charge_kick.length = self.length.repeat(shape)
         return new_space_charge_kick

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -66,6 +66,7 @@ class Undulator(Element):
             length=self.length.repeat(shape),
             is_active=self.is_active,
             name=self.name,
+            device=self.length.device,
         )
 
     @property

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -68,7 +68,11 @@ class VerticalCorrector(Element):
 
     def broadcast(self, shape: Size) -> Element:
         return self.__class__(
-            length=self.length.repeat(shape), angle=self.angle, name=self.name
+            length=self.length.repeat(shape),
+            angle=self.angle,
+            name=self.name,
+            device=self.length.device,
+            dtype=self.length.dtype,
         )
 
     @property

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -434,6 +434,8 @@ class ParameterBeam(Beam):
             cov=self._cov.repeat((*shape, 1, 1)),
             energy=self.energy.repeat(shape),
             total_charge=self.total_charge.repeat(shape),
+            device=self._mu.device,
+            dtype=self._mu.dtype,
         )
 
     def __repr__(self) -> str:

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -926,6 +926,8 @@ class ParticleBeam(Beam):
             particles=self.particles.repeat((*shape, 1, 1)),
             energy=self.energy.repeat(shape),
             particle_charges=self.particle_charges.repeat((*shape, 1)),
+            device=self.particles.device,
+            dtype=self.particles.dtype,
         )
 
     def __repr__(self) -> str:

--- a/tests/test_vectorized.py
+++ b/tests/test_vectorized.py
@@ -404,6 +404,28 @@ def test_broadcast_customtransfermap():
             assert torch.all(broadcast_element._transfer_map[i, j] == tm[0])
 
 
+def test_broadcast_element_keeps_dtype():
+    """Test that broadcasting an element keeps the same dtype."""
+    element = cheetah.Drift(length=torch.tensor([0.4]), dtype=torch.float64)
+    broadcast_element = element.broadcast((3, 10))
+
+    assert broadcast_element.length.dtype == torch.float64
+
+
+def test_broadcast_beam_keeps_dtype():
+    """Test that broadcasting a beam keeps the same dtype."""
+    beam = cheetah.ParticleBeam.from_parameters(
+        num_particles=100_000, sigma_x=torch.tensor([1e-5]), dtype=torch.float64
+    )
+    broadcast_beam = beam.broadcast((2,))
+    drift = cheetah.Drift(length=torch.tensor([0.4, 0.4]), dtype=torch.float64)
+
+    assert broadcast_beam.particles.dtype == torch.float64
+
+    # This should not raise an error
+    _ = drift(broadcast_beam)
+
+
 def test_broadcast_drift():
     """Test that broadcasting a `Drift` element gives the correct result."""
     element = cheetah.Drift(length=torch.tensor([0.4]))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Now broadcasting elements and beams will keep the dtype and device

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
