### PR TITLE
Implement vectorized split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚨 Breaking Changes
 
-- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198, #215, #218) (@jank324, @cr-xu)
+- Cheetah is now vectorised. This means that you can run multiple simulations in parallel by passing a batch of beams and settings, resulting a number of interfaces being changed. For Cheetah developers this means that you now have to account for an arbitrary-dimensional tensor of most of the properties of you element, rather than a single value, vector or whatever else a property was before. (see #116, #157, #170, #172, #173, #198, #215, #218, #229) (@jank324, @cr-xu, @hespe)
 - The fifth particle coordinate `s` is renamed to `tau`. Now Cheetah uses the canonical variables in phase space $(x,px=\frac{P_x}{p_0},y,py, \tau=c\Delta t, \delta=\Delta E/{p_0 c})$. In addition, the trailing "s" was removed from some beam property names (e.g. `beam.xs` becomes `beam.x`). (see #163) (@cr-xu)
 
 ### 🚀 Features

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -72,17 +72,15 @@ class Drift(Element):
         return True
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            element = Drift(
-                torch.min(resolution, remaining),
+        num_splits = torch.ceil(torch.max(self.length) / resolution).int()
+        return [
+            Drift(
+                self.length / num_splits,
                 dtype=self.length.dtype,
                 device=self.length.device,
             )
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
+            for i in range(num_splits)
+        ]
 
     def plot(self, ax: plt.Axes, s: float) -> None:
         pass

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -85,19 +85,16 @@ class HorizontalCorrector(Element):
         return any(self.angle != 0)
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            length = torch.min(resolution, remaining)
-            element = HorizontalCorrector(
-                length,
-                self.angle * length / self.length,
+        num_splits = torch.ceil(torch.max(self.length) / resolution).int()
+        return [
+            HorizontalCorrector(
+                self.length / num_splits,
+                self.angle / num_splits,
                 dtype=self.length.dtype,
                 device=self.length.device,
             )
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
+            for i in range(num_splits)
+        ]
 
     def plot(self, ax: plt.Axes, s: float) -> None:
         alpha = 1 if self.is_active else 0.2

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -218,11 +218,10 @@ class Quadrupole(Element):
         return any(self.k1 != 0)
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            element = Quadrupole(
-                torch.min(resolution, remaining),
+        num_splits = torch.ceil(torch.max(self.length) / resolution).int()
+        return [
+            Quadrupole(
+                self.length / num_splits,
                 self.k1,
                 misalignment=self.misalignment,
                 tilt=self.tilt,
@@ -231,9 +230,8 @@ class Quadrupole(Element):
                 dtype=self.length.dtype,
                 device=self.length.device,
             )
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
+            for i in range(num_splits)
+        ]
 
     def plot(self, ax: plt.Axes, s: float) -> None:
         alpha = 1 if self.is_active else 0.2

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -84,19 +84,16 @@ class VerticalCorrector(Element):
         return any(self.angle != 0)
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
-        split_elements = []
-        remaining = self.length
-        while remaining > 0:
-            length = torch.min(resolution, remaining)
-            element = VerticalCorrector(
-                length,
-                self.angle * length / self.length,
-                device=self.length.device,
+        num_splits = torch.ceil(torch.max(self.length) / resolution).int()
+        return [
+            VerticalCorrector(
+                self.length / num_splits,
+                self.angle / num_splits,
                 dtype=self.length.dtype,
+                device=self.length.device,
             )
-            split_elements.append(element)
-            remaining -= resolution
-        return split_elements
+            for i in range(num_splits)
+        ]
 
     def plot(self, ax: plt.Axes, s: float) -> None:
         alpha = 1 if self.is_active else 0.2

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -9,12 +9,12 @@ def test_drift_end():
     Test that at the end of a split drift the result is the same as at the end of the
     original drift.
     """
-    original_drift = cheetah.Drift(length=torch.tensor([2.0]))
+    original_drift = cheetah.Drift(length=torch.tensor([2.0, 2.5]))
     split_drift = cheetah.Segment(original_drift.split(resolution=torch.tensor(0.1)))
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_drift.track(incoming_beam)
     outgoing_beam_split = split_drift.track(incoming_beam)
@@ -30,7 +30,7 @@ def test_quadrupole_end():
     the original quadrupole.
     """
     original_quadrupole = cheetah.Quadrupole(
-        length=torch.tensor([0.2]), k1=torch.tensor([4.2])
+        length=torch.tensor([0.2, 0.3]), k1=torch.tensor([4.2, 3.6])
     )
     split_quadrupole = cheetah.Segment(
         original_quadrupole.split(resolution=torch.tensor(0.01))
@@ -38,7 +38,7 @@ def test_quadrupole_end():
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_quadrupole.track(incoming_beam)
     outgoing_beam_split = split_quadrupole.track(incoming_beam)
@@ -54,16 +54,16 @@ def test_cavity_end():
     the original cavity.
     """
     original_cavity = cheetah.Cavity(
-        length=torch.tensor([1.0377]),
-        voltage=torch.tensor([0.01815975e9]),
-        frequency=torch.tensor([1.3e9]),
-        phase=torch.tensor([0.0]),
+        length=torch.tensor([1.0377, 2.0377]),
+        voltage=torch.tensor([0.01815975e9, 9.15975e6]),
+        frequency=torch.tensor([1.3e9, 3.9e9]),
+        phase=torch.tensor([0.0, 4.2]),
     )
     split_cavity = cheetah.Segment(original_cavity.split(resolution=torch.tensor(0.1)))
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_cavity.track(incoming_beam)
     outgoing_beam_split = split_cavity.track(incoming_beam)
@@ -103,13 +103,13 @@ def test_dipole_end():
     the original dipole.
     """
     original_dipole = cheetah.Dipole(
-        length=torch.tensor([0.2]), angle=torch.tensor([4.2])
+        length=torch.tensor([0.2, 0.3]), angle=torch.tensor([4.2, 3.6])
     )
     split_dipole = cheetah.Segment(original_dipole.split(resolution=torch.tensor(0.01)))
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_dipole.track(incoming_beam)
     outgoing_beam_split = split_dipole.track(incoming_beam)
@@ -148,7 +148,7 @@ def test_horizontal_corrector_end():
     the end of the original horizontal corrector.
     """
     original_horizontal_corrector = cheetah.HorizontalCorrector(
-        length=torch.tensor([0.2]), angle=torch.tensor([4.2])
+        length=torch.tensor([0.2, 0.3]), angle=torch.tensor([4.2, 3.6])
     )
     split_horizontal_corrector = cheetah.Segment(
         original_horizontal_corrector.split(resolution=torch.tensor(0.01))
@@ -156,7 +156,7 @@ def test_horizontal_corrector_end():
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_horizontal_corrector.track(incoming_beam)
     outgoing_beam_split = split_horizontal_corrector.track(incoming_beam)
@@ -173,7 +173,7 @@ def test_vertical_corrector_end():
     the end of the original vertical corrector.
     """
     original_vertical_corrector = cheetah.VerticalCorrector(
-        length=torch.tensor([0.2]), angle=torch.tensor([4.2])
+        length=torch.tensor([0.2, 0.3]), angle=torch.tensor([4.2, 3.6])
     )
     split_vertical_corrector = cheetah.Segment(
         original_vertical_corrector.split(resolution=torch.tensor(0.01))
@@ -181,7 +181,7 @@ def test_vertical_corrector_end():
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_vertical_corrector.track(incoming_beam)
     outgoing_beam_split = split_vertical_corrector.track(incoming_beam)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -4,7 +4,6 @@ import torch
 import cheetah
 
 
-@pytest.mark.xfail  # TODO: Fix this
 def test_drift_end():
     """
     Test that at the end of a split drift the result is the same as at the end of the
@@ -25,7 +24,6 @@ def test_drift_end():
     )
 
 
-@pytest.mark.xfail  # TODO: Fix this
 def test_quadrupole_end():
     """
     Test that at the end of a split quadrupole the result is the same as at the end of

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -79,7 +79,7 @@ def test_solenoid_end():
     the original solenoid.
     """
     original_solenoid = cheetah.Solenoid(
-        length=torch.tensor([0.2]), k=torch.tensor([4.2])
+        length=torch.tensor([0.2, 0.3]), k=torch.tensor([4.2, 3.6])
     )
     split_solenoid = cheetah.Segment(
         original_solenoid.split(resolution=torch.tensor(0.01))
@@ -87,7 +87,7 @@ def test_solenoid_end():
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_solenoid.track(incoming_beam)
     outgoing_beam_split = split_solenoid.track(incoming_beam)
@@ -124,14 +124,14 @@ def test_undulator_end():
     Test that at the end of a split undulator the result is the same as at the end of
     the original undulator.
     """
-    original_undulator = cheetah.Undulator(length=torch.tensor([3.142]))
+    original_undulator = cheetah.Undulator(length=torch.tensor([3.142, 2.7]))
     split_undulator = cheetah.Segment(
         original_undulator.split(resolution=torch.tensor(0.1))
     )
 
     incoming_beam = cheetah.ParticleBeam.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001"
-    )
+    ).broadcast((2,))
 
     outgoing_beam_original = original_undulator.track(incoming_beam)
     outgoing_beam_split = split_undulator.track(incoming_beam)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current split implementation is not vectorized and fails on vectorized elements

<!--- Describe your changes in detail -->

## Motivation and Context

The implementation is changed to treat `resolution` as an upper bound on the length of the resulting subelements. This ensures that the elements will be divided into equally many subelements, even if the vectorized lengths are different.

Because of this change, the subelements are now assigned uniform length, instead of having the final element fill the gap to the total length. This could be considered to be a __breaking change__, but most likely no one relied on that exact behaviour.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (#227)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
