### PR TITLE
Add dipole beam focussing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `Screen` now offers the option to use KDE for differentiable images (see #200) (@cr-xu, @roussel-ryan)
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
+- `Dipole` can now include a focussing strength (see #235) (@hespe)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `Screen` now offers the option to use KDE for differentiable images (see #200) (@cr-xu, @roussel-ryan)
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
-- `Dipole` can now include a focussing strength (see #235) (@hespe)
+- `Dipole` now takes a focusing moment `k1` (see #235) (@hespe)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -20,6 +20,7 @@ class Dipole(Element):
 
     :param length: Length in meters.
     :param angle: Deflection angle in rad.
+    :param k1: Focussing strength in 1/m^-2.
     :param e1: The angle of inclination of the entrance face [rad].
     :param e2: The angle of inclination of the exit face [rad].
     :param tilt: Tilt of the magnet in x-y plane [rad].
@@ -34,6 +35,7 @@ class Dipole(Element):
         self,
         length: Union[torch.Tensor, nn.Parameter],
         angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        k1: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         e1: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         e2: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         tilt: Optional[Union[torch.Tensor, nn.Parameter]] = None,
@@ -53,6 +55,14 @@ class Dipole(Element):
             (
                 torch.as_tensor(angle, **factory_kwargs)
                 if angle is not None
+                else torch.zeros_like(self.length)
+            ),
+        )
+        self.register_buffer(
+            "k1",
+            (
+                torch.as_tensor(k1, **factory_kwargs)
+                if k1 is not None
                 else torch.zeros_like(self.length)
             ),
         )
@@ -132,7 +142,7 @@ class Dipole(Element):
         if torch.any(self.length != 0.0):  # Bending magnet with finite length
             R = base_rmatrix(
                 length=self.length,
-                k1=torch.zeros_like(self.length),
+                k1=self.k1,
                 hx=self.hx,
                 tilt=torch.zeros_like(self.length),
                 energy=energy,
@@ -197,6 +207,7 @@ class Dipole(Element):
         return self.__class__(
             length=self.length.repeat(shape),
             angle=self.angle.repeat(shape),
+            k1=self.k1.repeat(shape),
             e1=self.e1.repeat(shape),
             e2=self.e2.repeat(shape),
             tilt=self.tilt.repeat(shape),
@@ -217,6 +228,7 @@ class Dipole(Element):
         return (
             f"{self.__class__.__name__}(length={repr(self.length)}, "
             + f"angle={repr(self.angle)}, "
+            + f"k1={repr(self.k1)}, "
             + f"e1={repr(self.e1)},"
             + f"e2={repr(self.e2)},"
             + f"tilt={repr(self.tilt)},"
@@ -231,6 +243,7 @@ class Dipole(Element):
         return super().defining_features + [
             "length",
             "angle",
+            "k1",
             "e1",
             "e2",
             "tilt",

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -1,6 +1,6 @@
 import torch
 
-from cheetah import Dipole, Drift, ParameterBeam, ParticleBeam, Segment
+from cheetah import Dipole, Drift, ParameterBeam, ParticleBeam, Quadrupole, Segment
 
 
 def test_dipole_off():
@@ -21,6 +21,26 @@ def test_dipole_off():
     assert dipole.name is not None
     assert torch.allclose(outbeam_dipole_off.sigma_x, outbeam_drift.sigma_x)
     assert not torch.allclose(outbeam_dipole_on.sigma_x, outbeam_drift.sigma_x)
+
+
+def test_dipole_focussing():
+    """
+    Test that a dipole with focussing moment behaves like a quadrupole
+    """
+    dipole = Dipole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
+    quad = Quadrupole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
+    incoming_beam = ParameterBeam.from_parameters(
+        sigma_px=torch.tensor([2e-7]), sigma_py=torch.tensor([2e-7])
+    )
+    outbeam_dipole_on = dipole(incoming_beam)
+    outbeam_quad = quad(incoming_beam)
+
+    dipole.k1 = torch.tensor([0.0], device=dipole.k1.device)
+    outbeam_dipole_off = dipole(incoming_beam)
+
+    assert dipole.name is not None
+    assert torch.allclose(outbeam_dipole_on.sigma_x, outbeam_quad.sigma_x)
+    assert not torch.allclose(outbeam_dipole_off.sigma_x, outbeam_quad.sigma_x)
 
 
 def test_dipole_batched_execution():

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -28,19 +28,19 @@ def test_dipole_focussing():
     Test that a dipole with focussing moment behaves like a quadrupole.
     """
     dipole = Dipole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
-    quad = Quadrupole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
+    quadrupole = Quadrupole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
     incoming_beam = ParameterBeam.from_parameters(
         sigma_px=torch.tensor([2e-7]), sigma_py=torch.tensor([2e-7])
     )
-    outbeam_dipole_on = dipole(incoming_beam)
-    outbeam_quad = quad(incoming_beam)
+    outbeam_dipole_on = dipole.track(incoming_beam)
+    outbeam_quadrupole = quadrupole.track(incoming_beam)
 
     dipole.k1 = torch.tensor([0.0], device=dipole.k1.device)
-    outbeam_dipole_off = dipole(incoming_beam)
+    outbeam_dipole_off = dipole.track(incoming_beam)
 
     assert dipole.name is not None
-    assert torch.allclose(outbeam_dipole_on.sigma_x, outbeam_quad.sigma_x)
-    assert not torch.allclose(outbeam_dipole_off.sigma_x, outbeam_quad.sigma_x)
+    assert torch.allclose(outbeam_dipole_on.sigma_x, outbeam_quadrupole.sigma_x)
+    assert not torch.allclose(outbeam_dipole_off.sigma_x, outbeam_quadrupole.sigma_x)
 
 
 def test_dipole_batched_execution():

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -25,7 +25,7 @@ def test_dipole_off():
 
 def test_dipole_focussing():
     """
-    Test that a dipole with focussing moment behaves like a quadrupole
+    Test that a dipole with focussing moment behaves like a quadrupole.
     """
     dipole = Dipole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))
     quad = Quadrupole(length=torch.tensor([1.0]), k1=torch.tensor([10.0]))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a focussing moment to dipole magnets.

<!--- Describe your changes in detail -->

## Motivation and Context

In the course of implementing the elegant lattice converter, one encouters sector bending magnets that feature both a bending angle and a focussing strength. Currently, there is no way to map these magnets into Cheetah `element`.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change, see #222

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
