### PR TITLE
Fix RBend broadcasting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `Screen` now offers the option to use KDE for differentiable images (see #200) (@cr-xu, @roussel-ryan)
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
-- `Dipole` and `Bend` now take a focusing moment `k1` (see #235, #247) (@hespe)
+- `Dipole` and `RBend` now take a focusing moment `k1` (see #235, #247) (@hespe)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `Screen` now offers the option to use KDE for differentiable images (see #200) (@cr-xu, @roussel-ryan)
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
-- `Dipole` now takes a focusing moment `k1` (see #235) (@hespe)
+- `Dipole` now takes a focusing moment `k1` (see #235, #247) (@hespe)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `Screen` now offers the option to use KDE for differentiable images (see #200) (@cr-xu, @roussel-ryan)
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
-- `Dipole` now takes a focusing moment `k1` (see #235, #247) (@hespe)
+- `Dipole` and `Bend` now take a focusing moment `k1` (see #235, #247) (@hespe)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/rbend.py
+++ b/cheetah/accelerator/rbend.py
@@ -16,6 +16,7 @@ class RBend(Dipole):
 
     :param length: Length in meters.
     :param angle: Deflection angle in rad.
+    :param k1: Focussing strength in 1/m^-2.
     :param e1: The angle of inclination of the entrance face [rad].
     :param e2: The angle of inclination of the exit face [rad].
     :param tilt: Tilt of the magnet in x-y plane [rad].
@@ -30,6 +31,7 @@ class RBend(Dipole):
         self,
         length: Optional[Union[torch.Tensor, nn.Parameter]],
         angle: Optional[Union[torch.Tensor, nn.Parameter]] = None,
+        k1: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         e1: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         e2: Optional[Union[torch.Tensor, nn.Parameter]] = None,
         tilt: Optional[Union[torch.Tensor, nn.Parameter]] = None,
@@ -43,20 +45,7 @@ class RBend(Dipole):
         super().__init__(
             length=length,
             angle=angle,
-            e1=e1,
-            e2=e2,
-            tilt=tilt,
-            fringe_integral=fringe_integral,
-            fringe_integral_exit=fringe_integral_exit,
-            gap=gap,
-            name=name,
-            device=device,
-            dtype=dtype,
-        )
-
-        super().__init__(
-            length=length,
-            angle=angle,
+            k1=k1,
             e1=e1,
             e2=e2,
             tilt=tilt,

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -1,6 +1,15 @@
+import pytest
 import torch
 
-from cheetah import Dipole, Drift, ParameterBeam, ParticleBeam, Quadrupole, Segment
+from cheetah import (
+    Dipole,
+    Drift,
+    ParameterBeam,
+    ParticleBeam,
+    Quadrupole,
+    RBend,
+    Segment,
+)
 
 
 def test_dipole_off():
@@ -43,22 +52,23 @@ def test_dipole_focussing():
     assert not torch.allclose(outbeam_dipole_off.sigma_x, outbeam_quadrupole.sigma_x)
 
 
-def test_dipole_batched_execution():
+@pytest.mark.parametrize("DipoleType", [Dipole, RBend])
+def test_dipole_batched_execution(DipoleType):
     """
     Test that a dipole with batch dimensions behaves as expected.
     """
-    batch_shape = torch.Size([3])
+    batch_shape = torch.Size([6])
     incoming = ParticleBeam.from_parameters(
-        num_particles=torch.tensor(1000000),
+        num_particles=torch.tensor(1_000_000),
         energy=torch.tensor([1e9]),
         mu_x=torch.tensor([1e-5]),
     ).broadcast(batch_shape)
     segment = Segment(
         [
-            Dipole(
+            DipoleType(
                 length=torch.tensor([0.5, 0.5, 0.5]),
                 angle=torch.tensor([0.1, 0.2, 0.1]),
-            ),
+            ).broadcast((2,)),
             Drift(length=torch.tensor([0.5])).broadcast(batch_shape),
         ]
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since the `RBend` is inheriting much of the `Dipole` implementation, #235 broke its broadcasting by introducing additional constructor arguments. This PR restores parity between the element constructors, fixing the inherited broadcasting method.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (#246)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
