### PR TITLE
Fix vectorized tracking for `TransverseDeflectingCavity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
 - Port Bmad-X tracking methods to Cheetah for `Quadrupole`, `Drift`, and `Dipole` (see #153, #240) (@jp-ga, @jank324)
-- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240) (@jp-ga)
+- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240, #278) (@jp-ga, @cr-xu)
 - `Dipole` and `RBend` now take a focusing moment `k1` (see #235, #247) (@hespe)
 - Implement a converter for lattice files imported from Elegant (see #222, #251, #273) (@hespe)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
 - Port Bmad-X tracking methods to Cheetah for `Quadrupole`, `Drift`, and `Dipole` (see #153, #240) (@jp-ga, @jank324)
-- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240, #278) (@jp-ga, @cr-xu)
+- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240, #278) (@jp-ga, @cr-xu, @jank324)
 - `Dipole` and `RBend` now take a focusing moment `k1` (see #235, #247) (@hespe)
 - Implement a converter for lattice files imported from Elegant (see #222, #251, #273) (@hespe)
 

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -151,39 +151,28 @@ class TransverseDeflectingCavity(Element):
             x_offset, y_offset, self.tilt, x, px, y, py
         )
 
-        # Broadcast the TDC parameters together
-        broadcast_shape = torch.broadcast_shapes(
-            self.length.shape,
-            self.voltage.shape,
-            self.phase.shape,
-            self.frequency.shape,
-            self.tilt.shape,
-        )
-
-        length = self.length.expand(broadcast_shape)
-        voltage = self.voltage.expand(broadcast_shape)
-        # Add dimension for macro-particles
-        frequency = self.frequency.expand(broadcast_shape).unsqueeze(-1)
-        tdc_phase = self.phase.expand(broadcast_shape).unsqueeze(-1)
-
         x, y, z = bmadx.track_a_drift(
-            length / 2, x, px, y, py, z, pz, p0c, electron_mass_eV
+            self.length / 2, x, px, y, py, z, pz, p0c, electron_mass_eV
         )
 
-        voltage = (voltage / p0c).unsqueeze(-1)
-        k_rf = 2 * torch.pi * frequency / speed_of_light
+        voltage = self.voltage / p0c
+        k_rf = 2 * torch.pi * self.frequency / speed_of_light
+        # Phase that the particle sees
         phase = (
             2
             * torch.pi
             * (
-                tdc_phase
-                - (bmadx.particle_rf_time(z, pz, p0c, electron_mass_eV) * frequency)
+                self.phase.unsqueeze(-1)
+                - (
+                    bmadx.particle_rf_time(z, pz, p0c, electron_mass_eV)
+                    * self.frequency.unsqueeze(-1)
+                )
             )
-        )  # Phase that the particle sees
+        )
 
         # TODO: Assigning px to px is really bad practice and should be separated into
         # two separate variables
-        px = px + voltage * torch.sin(phase)
+        px = px + voltage.unsqueeze(-1) * torch.sin(phase)
 
         beta_old = (
             (1 + pz)
@@ -191,7 +180,9 @@ class TransverseDeflectingCavity(Element):
             / torch.sqrt(((1 + pz) * p0c.unsqueeze(-1)) ** 2 + electron_mass_eV**2)
         )
         E_old = (1 + pz) * p0c.unsqueeze(-1) / beta_old
-        E_new = E_old + voltage * torch.cos(phase) * k_rf * x * p0c.unsqueeze(-1)
+        E_new = E_old + voltage.unsqueeze(-1) * torch.cos(phase) * k_rf.unsqueeze(
+            -1
+        ) * x * p0c.unsqueeze(-1)
         pc = torch.sqrt(E_new**2 - electron_mass_eV**2)
         beta = pc / E_new
 
@@ -199,7 +190,7 @@ class TransverseDeflectingCavity(Element):
         z = z * beta / beta_old
 
         x, y, z = bmadx.track_a_drift(
-            length / 2, x, px, y, py, z, pz, p0c, electron_mass_eV
+            self.length / 2, x, px, y, py, z, pz, p0c, electron_mass_eV
         )
 
         x, px, y, py = bmadx.offset_particle_unset(

--- a/tests/test_transverse_deflecting_cavity.py
+++ b/tests/test_transverse_deflecting_cavity.py
@@ -39,9 +39,10 @@ def test_transverse_deflecting_cavity_bmadx_tracking(dtype):
     )
 
 
-def test_transverse_deflecting_cavity_vectorisation():
+def test_transverse_deflecting_cavity_energy_length_vectorization():
     """
-    Test that the TDC supports vectroized tracking
+    Test that vectorised tracking through a TDC throws now exception and outputs the
+    correct shape, when the input beam's energy and the TDC's length are vectorised.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
         num_particles=torch.tensor(10_000),
@@ -49,7 +50,6 @@ def test_transverse_deflecting_cavity_vectorisation():
         sigma_py=torch.tensor(2e-7),
         energy=torch.tensor([50e6, 60e6]),
     )
-    # Vectorise voltage
     tdc = cheetah.TransverseDeflectingCavity(
         length=torch.tensor(1.0),
         voltage=torch.tensor([[1e7], [2e7], [3e7]]),
@@ -58,20 +58,46 @@ def test_transverse_deflecting_cavity_vectorisation():
         tracking_method="bmadx",
     )
 
-    # Run tracking
-    _ = tdc.track(incoming_beam)
+    outgoing_beam = tdc.track(incoming_beam)
 
-    # Vectorise phase
-    tdc2 = cheetah.TransverseDeflectingCavity(
+    assert outgoing_beam.particles.shape[:-2] == torch.Size([3, 2])
+
+
+def test_transverse_deflecting_cavity_energy_phase_vectorization():
+    """
+    Test that vectorised tracking through a TDC throws now exception and outputs the
+    correct shape, when the input beam's energy and the TDC's phase are vectorised.
+    """
+    incoming_beam = cheetah.ParticleBeam.from_parameters(
+        num_particles=torch.tensor(10_000),
+        sigma_px=torch.tensor(2e-7),
+        sigma_py=torch.tensor(2e-7),
+        energy=torch.tensor([50e6, 60e6]),
+    )
+    tdc = cheetah.TransverseDeflectingCavity(
         length=torch.tensor(1.0),
         voltage=torch.tensor(1e7),
         phase=torch.tensor([[0.6], [0.5], [0.4]]),
         frequency=torch.tensor(1e9),
         tracking_method="bmadx",
     )
-    _ = tdc2.track(incoming_beam)
 
-    # Vectorise frequency
+    outgoing_beam = tdc.track(incoming_beam)
+
+    assert outgoing_beam.particles.shape[:-2] == torch.Size([3, 2])
+
+
+def test_transverse_deflecting_cavity_energy_frequency_vectorization():
+    """
+    Test that vectorised tracking through a TDC throws now exception and outputs the
+    correct shape, when the input beam's energy and the TDC's frequency are vectorised.
+    """
+    incoming_beam = cheetah.ParticleBeam.from_parameters(
+        num_particles=torch.tensor(10_000),
+        sigma_px=torch.tensor(2e-7),
+        sigma_py=torch.tensor(2e-7),
+        energy=torch.tensor([50e6, 60e6]),
+    )
     tdc3 = cheetah.TransverseDeflectingCavity(
         length=torch.tensor(1.0),
         voltage=torch.tensor(1e7),
@@ -79,16 +105,31 @@ def test_transverse_deflecting_cavity_vectorisation():
         frequency=torch.tensor([[1e9], [2e9], [3e9]]),
         tracking_method="bmadx",
     )
+
     _ = tdc3.track(incoming_beam)
 
-    # Try vectorising all parameters
-    tdc4 = cheetah.TransverseDeflectingCavity(
+    assert _.particles.shape[:-2] == torch.Size([3, 2])
+
+
+def test_transverse_deflecting_cavity_all_parameters_vectorization():
+    """
+    Test that vectorised tracking through a TDC throws now exception and outputs the
+    correct shape, when all parameters are vectorised.
+    """
+    incoming_beam = cheetah.ParticleBeam.from_parameters(
+        num_particles=torch.tensor(10_000),
+        sigma_px=torch.tensor(2e-7),
+        sigma_py=torch.tensor(2e-7),
+        energy=torch.tensor([50e6, 60e6]),
+    )
+    tdc = cheetah.TransverseDeflectingCavity(
         length=torch.tensor(1.0),
         voltage=torch.ones([4, 1, 1, 1]) * 1e7,
         phase=torch.ones([1, 3, 1, 1]) * 0.4,
         frequency=torch.ones([1, 1, 2, 1]) * 1e9,
         tracking_method="bmadx",
     )
-    outgoing_beam = tdc4.track(incoming_beam)
+
+    outgoing_beam = tdc.track(incoming_beam)
 
     assert outgoing_beam.particles.shape[:-2] == torch.Size([4, 3, 2, 2])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds some missing dimensional expansions in the `TransverseDeflectingCavity` code to fix a bug with some vectorisation setups.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Fixes #270.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
