### PR TITLE
Fix plotting for segments with tensors that require gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Fix issue in Bmad import where collimators had no length by interpreting them as `Drift` + `Aperture` (see #249) (@jank324)
 - Fix NumPy 2 compatibility issues with PyTorch on Windows (see #220, #242) (@hespe)
 - Fix issue with Dipole hgap conversion in Bmad import (see #261) (@cr-xu)
+- Fix plotting for segments that contain tensors with `require_grad=True` (see #288) (@hespe)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -400,7 +400,7 @@ class Segment(Element):
             dimension_reordered_ss[vector_idx]
             if stacked_ss.dim() > 1
             else dimension_reordered_ss
-        )
+        ).detach()
 
         ax.plot([0, plot_ss[-1]], [0, 0], "--", color="black")
 
@@ -465,17 +465,17 @@ class Segment(Element):
             dimensions_reordered_ss[vector_idx]
             if stacked_ss.dim() > 1
             else dimensions_reordered_ss
-        )
+        ).detach()
         plot_xs = (
             dimension_reordered_xs[vector_idx]
             if stacked_xs.dim() > 2
             else dimension_reordered_xs
-        )
+        ).detach()
         plot_ys = (
             dimension_reordered_ys[vector_idx]
             if stacked_ys.dim() > 2
             else dimension_reordered_ys
-        )
+        ).detach()
 
         for particle_idx in range(num_particles):
             axx.plot(plot_ss, plot_xs[particle_idx])
@@ -558,7 +558,7 @@ class Segment(Element):
             dimension_reordered_s_positions[vector_idx]
             if stacked_s_positions.dim() > 1
             else dimension_reordered_s_positions
-        )
+        ).detach()
 
         broadcast_beta_x = torch.broadcast_tensors(*beta_x)
         stacked_beta_x = torch.stack(broadcast_beta_x)
@@ -567,7 +567,7 @@ class Segment(Element):
             dimension_reordered_beta_x[vector_idx]
             if stacked_beta_x.dim() > 2
             else dimension_reordered_beta_x
-        )
+        ).detach()
 
         broadcast_beta_y = torch.broadcast_tensors(*beta_y)
         stacked_beta_y = torch.stack(broadcast_beta_y)
@@ -576,7 +576,7 @@ class Segment(Element):
             dimension_reordered_beta_y[vector_idx]
             if stacked_beta_y.dim() > 2
             else dimension_reordered_beta_y
-        )
+        ).detach()
 
         if ax is None:
             fig = plt.figure()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -103,3 +103,17 @@ def test_reference_particle_plot_vectorized_2d():
 
     # Run the plotting to see if it raises an exception
     segment.plot_overview(incoming=incoming, resolution=0.1, vector_idx=(0, 2))
+
+
+def test_plotting_with_gradients():
+    """
+    Test that plotting doesn't raise an exception for segments that contain tensors
+    that require gradients.
+    """
+    segment = cheetah.Segment(
+        elements=[cheetah.Drift(length=torch.tensor(1.0, requires_grad=True))]
+    )
+    beam = cheetah.ParameterBeam.from_parameters()
+
+    segment.plot_overview(incoming=beam)
+    segment.plot_twiss(incoming=beam)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Cheetah plotting routines currently fail if `require_grad=True` is set for any of the involved tensors. The fix is to call `tensor.detach()` before calling matplotlib.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change
  - Closes #287 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
