### PR TITLE
Temporary fix for broken inactive`TransverseDeflectingCavity` in `Segment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Moving `Element`s and `Beam`s to a different `device` and changing their `dtype` like with any `torch.nn.Module` is now possible (see #209) (@jank324)
 - `Quadrupole` now supports tracking with Cheetah's matrix-based method or with Bmad's more accurate method (see #153) (@jp-ga, @jank324)
 - Port Bmad-X tracking methods to Cheetah for `Quadrupole`, `Drift`, and `Dipole` (see #153, #240) (@jp-ga, @jank324)
-- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240, #278) (@jp-ga, @cr-xu, @jank324)
+- Add `TransverseDeflectingCavity` element (following the Bmad-X implementation) (see #240, #278 #296) (@jp-ga, @cr-xu, @jank324)
 - `Dipole` and `RBend` now take a focusing moment `k1` (see #235, #247) (@hespe)
 - Implement a converter for lattice files imported from Elegant (see #222, #251, #273, #281) (@hespe, @jank324)
 

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -99,7 +99,8 @@ class TransverseDeflectingCavity(Element):
 
     @property
     def is_skippable(self) -> bool:
-        return not self.is_active
+        # TODO: Implement drrift-like `transfer_map` and set to `self.is_active`
+        return False
 
     def track(self, incoming: Beam) -> Beam:
         """

--- a/tests/test_transverse_deflecting_cavity.py
+++ b/tests/test_transverse_deflecting_cavity.py
@@ -133,3 +133,16 @@ def test_transverse_deflecting_cavity_all_parameters_vectorization():
     outgoing_beam = tdc.track(incoming_beam)
 
     assert outgoing_beam.particles.shape[:-2] == torch.Size([4, 3, 2, 2])
+
+
+def test_tracking_inactive_in_segment():
+    """
+    Test that tracking through a `Segment` that contains an inactive
+    `TransverseDeflectingCavity` does not throw an exception. This was an issue in #290.
+    """
+    segment = cheetah.Segment(
+        elements=[cheetah.TransverseDeflectingCavity(length=torch.tensor(1.0))]
+    )
+    beam = cheetah.ParticleBeam.from_parameters()
+
+    segment.track(beam)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Implements a temporary fix that prevents inactive `TransverseDeflectingCavity`s to take part in transfer map reduction.

Ideally, this should be fixed properly at some point to allow for fast tracking by implementing the `transfer_map` function or inheriting it from `Drift` in the future, to make sure this part of Cheetah is also as fast as it can be. For now the workaround for being fast is to replace inactive elements with `Drift` using the respective functions in `Segment` for doing exactly that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Calling `transfer_map` on `TransverseDeflectingCavity` would cause a `NotImplementedError` to be raised and therefore prevent tracking through any `Segment` that had an inactive `TransverseDeflectingCavity` in it.

Fixes #290.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
