### PR TITLE
Add test for using `nn.Parameter` as element length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Fix NumPy 2 compatibility issues with PyTorch on Windows (see #220, #242) (@hespe)
 - Fix issue with Dipole hgap conversion in Bmad import (see #261) (@cr-xu)
 - Fix plotting for segments that contain tensors with `require_grad=True` (see #288) (@hespe)
+- Fix bug where `Element.length` could not be set as a `torch.nn.Parameter` (see #301) (@jank324, @hespe)
 
 ### 🐆 Other
 

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -91,10 +91,8 @@ def test_drift_bmadx_tracking(dtype):
 
 
 def test_length_as_parameter():
-    """
-    Test that the drift length can be set as a torch.nn.Parameter.
-    """
-    length = torch.Tensor([1.0])
+    """Test that the drift length can be set as a `torch.nn.Parameter`."""
+    length = torch.Tensor(1.0)
     parameter = torch.nn.Parameter(length)
 
     # Create to equal drifts, one with Tensor, one with Parameter

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -92,7 +92,7 @@ def test_drift_bmadx_tracking(dtype):
 
 def test_length_as_parameter():
     """Test that the drift length can be set as a `torch.nn.Parameter`."""
-    length = torch.Tensor(1.0)
+    length = torch.tensor(1.0)
     parameter = torch.nn.Parameter(length)
 
     # Create to equal drifts, one with Tensor, one with Parameter

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -88,3 +88,25 @@ def test_drift_bmadx_tracking(dtype):
         atol=1e-14 if dtype == torch.float64 else 0.00001,
         rtol=1e-14 if dtype == torch.float64 else 1e-6,
     )
+
+
+def test_length_as_parameter():
+    """
+    Test that the drift length can be set as a torch.nn.Parameter.
+    """
+    length = torch.Tensor([1.0])
+    parameter = torch.nn.Parameter(length)
+
+    # Create to equal drifts, one with Tensor, one with Parameter
+    drift = cheetah.Drift(length=length)
+    drift_parameter = cheetah.Drift(length=parameter)
+
+    incoming = cheetah.ParameterBeam.from_parameters()
+    outgoing = drift.track(incoming)
+    outgoing_parameter = drift_parameter.track(incoming)
+
+    # Check that all properties of the two outgoing beams are same
+    for buffer, buffer_parameter in zip(
+        outgoing.buffers(), outgoing_parameter.buffers()
+    ):
+        assert torch.allclose(buffer, buffer_parameter)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

It was previously observed that `Element.length` cannot be set to `torch.nn.Parameter` instead of `torch.Tensor`. However, up-to-date version of Cheetah do already support such an assignment.

It is likely that the required change was introduced in 383ff83. To prevent the issue from reappearing, we implement a simple test case.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #164

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
