### PR TITLE
Fix `nn.Parameter` assignment at initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This is a major release with significant upgrades under the hood of Cheetah. Des
 - Fix issue with Dipole hgap conversion in Bmad import (see #261) (@cr-xu)
 - Fix plotting for segments that contain tensors with `require_grad=True` (see #288) (@hespe)
 - Fix bug where `Element.length` could not be set as a `torch.nn.Parameter` (see #301) (@jank324, @hespe)
+- Fix registration of `torch.nn.Parameter` at initilization for elements and beams (see #303) (@hespe)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/aperture.py
+++ b/cheetah/accelerator/aperture.py
@@ -37,7 +37,7 @@ class Aperture(Element):
     ) -> None:
         device, dtype = verify_device_and_dtype([x_max, y_max], device, dtype)
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("x_max", torch.tensor(float("inf"), **factory_kwargs))
         self.register_buffer("y_max", torch.tensor(float("inf"), **factory_kwargs))

--- a/cheetah/accelerator/aperture.py
+++ b/cheetah/accelerator/aperture.py
@@ -39,22 +39,14 @@ class Aperture(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer(
-            "x_max",
-            (
-                torch.as_tensor(x_max, **factory_kwargs)
-                if x_max is not None
-                else torch.tensor(float("inf"), **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "y_max",
-            (
-                torch.as_tensor(y_max, **factory_kwargs)
-                if y_max is not None
-                else torch.tensor(float("inf"), **factory_kwargs)
-            ),
-        )
+        self.register_buffer("x_max", torch.tensor(float("inf"), **factory_kwargs))
+        self.register_buffer("y_max", torch.tensor(float("inf"), **factory_kwargs))
+
+        if x_max is not None:
+            self.x_max = torch.as_tensor(x_max, **factory_kwargs)
+        if y_max is not None:
+            self.y_max = torch.as_tensor(y_max, **factory_kwargs)
+
         self.shape = shape
         self.is_active = is_active
 

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -47,31 +47,18 @@ class Cavity(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "voltage",
-            (
-                torch.as_tensor(voltage, **factory_kwargs)
-                if voltage is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "phase",
-            (
-                torch.as_tensor(phase, **factory_kwargs)
-                if phase is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "frequency",
-            (
-                torch.as_tensor(frequency, **factory_kwargs)
-                if frequency is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("frequency", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if voltage is not None:
+            self.voltage = torch.as_tensor(voltage, **factory_kwargs)
+        if phase is not None:
+            self.phase = torch.as_tensor(phase, **factory_kwargs)
+        if frequency is not None:
+            self.frequency = torch.as_tensor(frequency, **factory_kwargs)
 
     @property
     def is_active(self) -> bool:

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -45,7 +45,7 @@ class Cavity(Element):
             [length, voltage, phase, frequency], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -47,7 +47,6 @@ class Cavity(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("frequency", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -28,7 +28,7 @@ class CustomTransferMap(Element):
             [predefined_transfer_map, length], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         assert isinstance(predefined_transfer_map, torch.Tensor)
         assert predefined_transfer_map.shape[-2:] == (7, 7)

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -33,18 +33,14 @@ class CustomTransferMap(Element):
         assert isinstance(predefined_transfer_map, torch.Tensor)
         assert predefined_transfer_map.shape[-2:] == (7, 7)
 
-        self.register_buffer(
-            "predefined_transfer_map",
-            torch.as_tensor(predefined_transfer_map, **factory_kwargs),
+        self.register_buffer("predefined_transfer_map", None)
+        self.register_buffer("length", torch.tensor(0.0, **factory_kwargs))
+
+        self.predefined_transfer_map = torch.as_tensor(
+            predefined_transfer_map, **factory_kwargs
         )
-        self.register_buffer(
-            "length",
-            (
-                torch.as_tensor(length, **factory_kwargs)
-                if length is not None
-                else torch.zeros(predefined_transfer_map.shape[:-2], **factory_kwargs)
-            ),
-        )
+        if length is not None:
+            self.length = torch.as_tensor(length, **factory_kwargs)
 
     @classmethod
     def from_merging_elements(

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -34,7 +34,6 @@ class CustomTransferMap(Element):
         assert predefined_transfer_map.shape[-2:] == (7, 7)
 
         self.register_buffer("predefined_transfer_map", None)
-        self.register_buffer("length", torch.tensor(0.0, **factory_kwargs))
 
         self.predefined_transfer_map = torch.as_tensor(
             predefined_transfer_map, **factory_kwargs

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -82,7 +82,6 @@ class Dipole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name, **factory_kwargs)
 
-        self.register_buffer("length", None)
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("k1", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("_e1", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -80,7 +80,7 @@ class Dipole(Element):
             dtype,
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("length", None)
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -82,79 +82,43 @@ class Dipole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "angle",
-            (
-                torch.as_tensor(angle, **factory_kwargs)
-                if angle is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
+        self.register_buffer("length", None)
+        self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("k1", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("_e1", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("_e2", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("fringe_integral", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("fringe_integral_exit", None)
+        self.register_buffer("gap", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("gap_exit", None)
+        self.register_buffer("tilt", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if angle is not None:
+            self.angle = torch.as_tensor(angle, **factory_kwargs)
+        if k1 is not None:
+            self.k1 = torch.as_tensor(k1, **factory_kwargs)
+        if dipole_e1 is not None:
+            self._e1 = torch.as_tensor(dipole_e1, **factory_kwargs)
+        if dipole_e2 is not None:
+            self._e2 = torch.as_tensor(dipole_e2, **factory_kwargs)
+        if fringe_integral is not None:
+            self.fringe_integral = torch.as_tensor(fringe_integral, **factory_kwargs)
+        self.fringe_integral_exit = (
+            torch.tensor(fringe_integral_exit, **factory_kwargs)
+            if fringe_integral_exit is not None
+            else self.fringe_integral
         )
-        self.register_buffer(
-            "k1",
-            (
-                torch.as_tensor(k1, **factory_kwargs)
-                if k1 is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
+        if gap is not None:
+            self.gap = torch.as_tensor(gap, **factory_kwargs)
+        self.gap_exit = (
+            torch.tensor(gap_exit, **factory_kwargs)
+            if gap_exit is not None
+            else self.gap
         )
-        self.register_buffer(
-            "_e1",
-            (
-                torch.as_tensor(dipole_e1, **factory_kwargs)
-                if dipole_e1 is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "_e2",
-            (
-                torch.as_tensor(dipole_e2, **factory_kwargs)
-                if dipole_e2 is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "fringe_integral",
-            (
-                torch.as_tensor(fringe_integral, **factory_kwargs)
-                if fringe_integral is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "fringe_integral_exit",
-            (
-                self.fringe_integral
-                if fringe_integral_exit is None
-                else torch.tensor(fringe_integral_exit, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "gap",
-            (
-                torch.as_tensor(gap, **factory_kwargs)
-                if gap is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "gap_exit",
-            (
-                torch.as_tensor(gap_exit, **factory_kwargs)
-                if gap_exit is not None
-                else 1.0 * self.gap
-            ),
-        )
-        self.register_buffer(
-            "tilt",
-            (
-                torch.as_tensor(tilt, **factory_kwargs)
-                if tilt is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        if tilt is not None:
+            self.tilt = torch.as_tensor(tilt, **factory_kwargs)
+
         self.fringe_at = fringe_at
         self.fringe_type = fringe_type
         self.tracking_method = tracking_method

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -36,10 +36,8 @@ class Drift(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
-        self.tracking_method = tracking_method
-
         self.length = torch.as_tensor(length, **factory_kwargs)
+        self.tracking_method = tracking_method
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         device = self.length.device

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -34,7 +34,7 @@ class Drift(Element):
         dtype=None,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.length = torch.as_tensor(length, **factory_kwargs)
         self.tracking_method = tracking_method

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -36,8 +36,10 @@ class Drift(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer("length", None)
         self.tracking_method = tracking_method
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         device = self.length.device

--- a/cheetah/accelerator/element.py
+++ b/cheetah/accelerator/element.py
@@ -19,11 +19,11 @@ class Element(ABC, nn.Module):
     :param name: Unique identifier of the element.
     """
 
-    def __init__(self, name: Optional[str] = None) -> None:
+    def __init__(self, name: Optional[str] = None, device=None, dtype=None) -> None:
         super().__init__()
 
         self.name = name if name is not None else generate_unique_name()
-        self.register_buffer("length", torch.tensor(0.0))
+        self.register_buffer("length", torch.tensor(0.0, device=device, dtype=dtype))
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         r"""

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -36,7 +36,7 @@ class HorizontalCorrector(Element):
     ) -> None:
         device, dtype = verify_device_and_dtype([length, angle], device, dtype)
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
 

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -38,7 +38,6 @@ class HorizontalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
 
         self.length = torch.as_tensor(length, **factory_kwargs)

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -38,15 +38,12 @@ class HorizontalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "angle",
-            (
-                torch.as_tensor(angle, **factory_kwargs)
-                if angle is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if angle is not None:
+            self.angle = torch.as_tensor(angle, **factory_kwargs)
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         device = self.length.device

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -47,7 +47,7 @@ class Quadrupole(Element):
             [length, k1, misalignment, tilt], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("k1", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -49,31 +49,19 @@ class Quadrupole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "k1",
-            (
-                torch.as_tensor(k1, **factory_kwargs)
-                if k1 is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "misalignment",
-            (
-                torch.as_tensor(misalignment, **factory_kwargs)
-                if misalignment is not None
-                else torch.zeros((*self.length.shape, 2), **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "tilt",
-            (
-                torch.as_tensor(tilt, **factory_kwargs)
-                if tilt is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("k1", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
+        self.register_buffer("tilt", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if k1 is not None:
+            self.k1 = torch.as_tensor(k1, **factory_kwargs)
+        if misalignment is not None:
+            self.misalignment = torch.as_tensor(misalignment, **factory_kwargs)
+        if tilt is not None:
+            self.tilt = torch.as_tensor(tilt, **factory_kwargs)
+
         self.num_steps = num_steps
         self.tracking_method = tracking_method
 

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -49,7 +49,6 @@ class Quadrupole(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("k1", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
         self.register_buffer("tilt", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -57,7 +57,7 @@ class Screen(Element):
             [pixel_size, misalignment, kde_bandwidth], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         assert method in [
             "histogram",

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -70,34 +70,17 @@ class Screen(Element):
         self.is_blocking = is_blocking
         self.is_active = is_active
 
-        self.register_buffer(
-            "pixel_size",
-            (
-                torch.as_tensor(pixel_size, **factory_kwargs)
-                if pixel_size is not None
-                else torch.tensor((1e-3, 1e-3), **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "misalignment",
-            (
-                torch.as_tensor(misalignment, **factory_kwargs)
-                if misalignment is not None
-                else torch.tensor((0.0, 0.0), **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "length",
-            torch.zeros(self.misalignment.shape[:-1], **factory_kwargs),
-        )
-        self.register_buffer(
-            "kde_bandwidth",
-            (
-                torch.as_tensor(kde_bandwidth, **factory_kwargs)
-                if kde_bandwidth is not None
-                else torch.clone(self.pixel_size[0])
-            ),
-        )
+        self.register_buffer("length", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("pixel_size", torch.tensor((1e-3, 1e-3), **factory_kwargs))
+        self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
+        self.register_buffer("kde_bandwidth", torch.clone(self.pixel_size[0]))
+
+        if pixel_size is not None:
+            self.pixel_size = torch.as_tensor(pixel_size, **factory_kwargs)
+        if misalignment is not None:
+            self.misalignment = torch.as_tensor(misalignment, **factory_kwargs)
+        if kde_bandwidth is not None:
+            self.kde_bandwidth = torch.as_tensor(kde_bandwidth, **factory_kwargs)
 
         self.set_read_beam(None)
         self.cached_reading = None

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -70,7 +70,6 @@ class Screen(Element):
         self.is_blocking = is_blocking
         self.is_active = is_active
 
-        self.register_buffer("length", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("pixel_size", torch.tensor((1e-3, 1e-3), **factory_kwargs))
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
         self.register_buffer("kde_bandwidth", torch.clone(self.pixel_size[0]))

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -47,23 +47,15 @@ class Solenoid(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "k",
-            (
-                torch.as_tensor(k, **factory_kwargs)
-                if k is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "misalignment",
-            (
-                torch.as_tensor(misalignment, **factory_kwargs)
-                if misalignment is not None
-                else torch.zeros((*self.length.shape[:-1], 2), **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("k", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if k is not None:
+            self.k = torch.as_tensor(k, **factory_kwargs)
+        if misalignment is not None:
+            self.misalignment = torch.as_tensor(misalignment, **factory_kwargs)
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         device = self.length.device

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -47,7 +47,6 @@ class Solenoid(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("k", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
 

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -45,7 +45,7 @@ class Solenoid(Element):
             [length, k, misalignment], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("k", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -65,19 +65,16 @@ class SpaceChargeKick(Element):
 
         self.grid_shape = (num_grid_points_x, num_grid_points_y, num_grid_points_tau)
 
-        self.register_buffer(
-            "effect_length", torch.as_tensor(effect_length, **self.factory_kwargs)
-        )
+        self.register_buffer("effect_length", None)
         # In multiples of sigma
-        self.register_buffer(
-            "grid_extend_x", torch.as_tensor(grid_extend_x, **self.factory_kwargs)
-        )
-        self.register_buffer(
-            "grid_extend_y", torch.as_tensor(grid_extend_y, **self.factory_kwargs)
-        )
-        self.register_buffer(
-            "grid_extend_tau", torch.as_tensor(grid_extend_tau, **self.factory_kwargs)
-        )
+        self.register_buffer("grid_extend_x", None)
+        self.register_buffer("grid_extend_y", None)
+        self.register_buffer("grid_extend_tau", None)
+
+        self.effect_length = torch.as_tensor(effect_length, **self.factory_kwargs)
+        self.grid_extend_x = torch.as_tensor(grid_extend_x, **self.factory_kwargs)
+        self.grid_extend_y = torch.as_tensor(grid_extend_y, **self.factory_kwargs)
+        self.grid_extend_tau = torch.as_tensor(grid_extend_tau, **self.factory_kwargs)
 
     def _deposit_charge_on_grid(
         self,

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -61,7 +61,7 @@ class SpaceChargeKick(Element):
         device, dtype = verify_device_and_dtype([effect_length], device, dtype)
         self.factory_kwargs = {"device": device, "dtype": dtype}
 
-        super().__init__(name=name)
+        super().__init__(name=name, **self.factory_kwargs)
 
         self.grid_shape = (num_grid_points_x, num_grid_points_y, num_grid_points_tau)
 

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -51,7 +51,6 @@ class TransverseDeflectingCavity(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("frequency", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -49,7 +49,7 @@ class TransverseDeflectingCavity(Element):
             [length, voltage, phase, frequency, misalignment, tilt], device, dtype
         )
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
         self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -51,47 +51,25 @@ class TransverseDeflectingCavity(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "voltage",
-            (
-                torch.as_tensor(voltage, **factory_kwargs)
-                if voltage is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "phase",
-            (
-                torch.as_tensor(phase, **factory_kwargs)
-                if phase is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "frequency",
-            (
-                torch.as_tensor(frequency, **factory_kwargs)
-                if frequency is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "misalignment",
-            (
-                torch.as_tensor(misalignment, **factory_kwargs)
-                if misalignment is not None
-                else torch.zeros((*self.length.shape, 2), **factory_kwargs)
-            ),
-        )
-        self.register_buffer(
-            "tilt",
-            (
-                torch.as_tensor(tilt, **factory_kwargs)
-                if tilt is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("voltage", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("phase", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("frequency", torch.tensor(0.0, **factory_kwargs))
+        self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
+        self.register_buffer("tilt", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if voltage is not None:
+            self.voltage = torch.as_tensor(voltage, **factory_kwargs)
+        if phase is not None:
+            self.phase = torch.as_tensor(phase, **factory_kwargs)
+        if frequency is not None:
+            self.frequency = torch.as_tensor(frequency, **factory_kwargs)
+        if misalignment is not None:
+            self.misalignment = torch.as_tensor(misalignment, **factory_kwargs)
+        if tilt is not None:
+            self.tilt = torch.as_tensor(tilt, **factory_kwargs)
+
         self.num_steps = num_steps
         self.tracking_method = tracking_method
 

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -34,7 +34,7 @@ class Undulator(Element):
         dtype=None,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.length = torch.as_tensor(length, **factory_kwargs)
         self.is_active = is_active

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -36,8 +36,6 @@ class Undulator(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
-
         self.length = torch.as_tensor(length, **factory_kwargs)
         self.is_active = is_active
 

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -36,7 +36,9 @@ class Undulator(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
+        self.register_buffer("length", None)
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
         self.is_active = is_active
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -41,15 +41,12 @@ class VerticalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", torch.as_tensor(length, **factory_kwargs))
-        self.register_buffer(
-            "angle",
-            (
-                torch.as_tensor(angle, **factory_kwargs)
-                if angle is not None
-                else torch.tensor(0.0, **factory_kwargs)
-            ),
-        )
+        self.register_buffer("length", None)
+        self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
+
+        self.length = torch.as_tensor(length, **factory_kwargs)
+        if angle is not None:
+            self.angle = torch.as_tensor(angle, **factory_kwargs)
 
     def transfer_map(self, energy: torch.Tensor) -> torch.Tensor:
         device = self.length.device

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -41,7 +41,6 @@ class VerticalCorrector(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name)
 
-        self.register_buffer("length", None)
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
 
         self.length = torch.as_tensor(length, **factory_kwargs)

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -39,7 +39,7 @@ class VerticalCorrector(Element):
     ) -> None:
         device, dtype = verify_device_and_dtype([length, angle], device, dtype)
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(name=name)
+        super().__init__(name=name, **factory_kwargs)
 
         self.register_buffer("angle", torch.tensor(0.0, **factory_kwargs))
 

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -35,17 +35,16 @@ class ParameterBeam(Beam):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
 
-        self.register_buffer("_mu", torch.as_tensor(mu, **factory_kwargs))
-        self.register_buffer("_cov", torch.as_tensor(cov, **factory_kwargs))
-        total_charge = (
-            total_charge
-            if total_charge is not None
-            else torch.tensor([0.0], **factory_kwargs)
-        )
-        self.register_buffer(
-            "total_charge", torch.as_tensor(total_charge, **factory_kwargs)
-        )
-        self.register_buffer("energy", torch.as_tensor(energy, **factory_kwargs))
+        self.register_buffer("_mu", None)
+        self.register_buffer("_cov", None)
+        self.register_buffer("energy", None)
+        self.register_buffer("total_charge", torch.tensor(0.0, **factory_kwargs))
+
+        self._mu = torch.as_tensor(mu, **factory_kwargs)
+        self._cov = torch.as_tensor(cov, **factory_kwargs)
+        self.energy = torch.as_tensor(energy, **factory_kwargs)
+        if total_charge is not None:
+            self.total_charge = torch.as_tensor(total_charge, **factory_kwargs)
 
     @classmethod
     def from_parameters(

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -54,24 +54,21 @@ class ParticleBeam(Beam):
             particles.shape[-2] > 0 and particles.shape[-1] == 7
         ), "Particle vectors must be 7-dimensional."
 
-        self.register_buffer("particles", particles.to(**factory_kwargs))
+        self.register_buffer("particles", None)
+        self.register_buffer("energy", None)
         self.register_buffer(
-            "particle_charges",
-            (
-                particle_charges.to(**factory_kwargs)
-                if particle_charges is not None
-                else torch.zeros(particles.shape[-2], **factory_kwargs)
-            ),
+            "particle_charges", torch.zeros(particles.shape[-2], **factory_kwargs)
         )
-        self.register_buffer("energy", energy.to(**factory_kwargs))
         self.register_buffer(
-            "survival_probabilities",
-            (
-                survival_probabilities.to(**factory_kwargs)
-                if survival_probabilities is not None
-                else torch.ones(particles.shape[-2], **factory_kwargs)
-            ),
+            "survival_probabilities", torch.ones(particles.shape[-2], **factory_kwargs)
         )
+
+        self.particles = particles.to(**factory_kwargs)
+        self.energy = energy.to(**factory_kwargs)
+        if particle_charges is not None:
+            self.particle_charges = particle_charges.to(**factory_kwargs)
+        if survival_probabilities is not None:
+            self.survival_probabilities = survival_probabilities.to(**factory_kwargs)
 
     @classmethod
     def from_parameters(

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -147,3 +147,27 @@ def test_nonleaf_lenghtless_elements(ElementClass):
         ]
     )
     segment.track(beam)
+
+
+def test_parameters_at_initialization():
+    """
+    Test that passing a `torch.nn.Parameter` at initialization registeres the parameter
+    in the same way as an assignment after initialization.
+    """
+    dipole_with_buffer = cheetah.Dipole(length=torch.tensor(1.0))
+
+    # Dipole with buffer (without parameter) should not have any parameters
+    assert len(list(dipole_with_buffer.parameters())) == 0
+
+    # Create two dipoles with the same parameter, one passed at initialization and one
+    # assigned after initialization.
+    parameter = torch.nn.Parameter(torch.tensor(0.2))
+    dipole_initial = cheetah.Dipole(length=torch.tensor(1.0), angle=parameter)
+    dipole_assigned = cheetah.Dipole(length=torch.tensor(1.0))
+    dipole_assigned.angle = parameter
+
+    # Both dipoles should have the same parameter (the originally passed one and one in
+    # total)
+    assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
+    assert len(list(dipole_initial.parameters())) == 1
+    assert parameter in dipole_initial.parameters()

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -169,7 +169,5 @@ def test_parameters_at_initialization():
     # Both dipoles should have the same parameter (the originally passed one and one in
     # total)
     assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
-    assert list(dipole_initial.buffers()) == list(dipole_assigned.buffers())
     assert len(list(dipole_initial.parameters())) == 1
     assert parameter in dipole_initial.parameters()
-    assert parameter not in dipole_initial.buffers()

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -169,5 +169,7 @@ def test_parameters_at_initialization():
     # Both dipoles should have the same parameter (the originally passed one and one in
     # total)
     assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
+    assert list(dipole_initial.buffers()) == list(dipole_assigned.buffers())
     assert len(list(dipole_initial.parameters())) == 1
     assert parameter in dipole_initial.parameters()
+    assert parameter not in dipole_initial.buffers()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -155,3 +155,17 @@ def test_dipole_bmadx_tracking(dtype):
         rtol=1e-14 if dtype == torch.float64 else 0.00001,
         atol=1e-14 if dtype == torch.float64 else 1e-6,
     )
+
+
+def test_buffer_registration():
+    """
+    Test that buffers are properly registered in the dipole element.
+    """
+    length = torch.tensor(0.5)
+    gap_exit = torch.tensor(0.1)
+    dipole = Dipole(length=length, gap_exit=gap_exit)
+
+    # length and gap_exit are tested because they behave slightly different than other
+    # properties. length is inherited and gap_exit is derived from gap by default.
+    assert length in dipole.buffers()
+    assert gap_exit in dipole.buffers()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -159,18 +159,23 @@ def test_dipole_bmadx_tracking(dtype):
 
 def test_parameters_at_initialization():
     """
-    Test that passing a `torch.nn.Parameter` at initialization registeres the
-    parameter in the same way as an assignment after initialization.
+    Test that passing a `torch.nn.Parameter` at initialization registeres the parameter
+    in the same way as an assignment after initialization.
     """
-    param = torch.nn.Parameter(torch.tensor(0.2))
+    dipole_with_buffer = Dipole(length=torch.tensor(1.0))
 
-    dipole = Dipole(length=torch.tensor(1.0))
-    dipole_parameter = Dipole(length=torch.tensor(1.0), angle=param)
+    # Dipole with buffer (without parameter) should not have any parameters
+    assert len(list(dipole_with_buffer.parameters())) == 0
 
-    assert len(list(dipole.parameters())) == 0
-    dipole.angle = param
-    assert len(list(dipole.parameters())) == 1
-    assert param in dipole.parameters()
+    # Create two dipoles with the same parameter, one passed at initialization and one
+    # assigned after initialization.
+    parameter = torch.nn.Parameter(torch.tensor(0.2))
+    dipole_initial = Dipole(length=torch.tensor(1.0), angle=parameter)
+    dipole_assigned = Dipole(length=torch.tensor(1.0))
+    dipole_assigned.angle = parameter
 
-    assert len(list(dipole_parameter.parameters())) == 1
-    assert param in dipole_parameter.parameters()
+    # Both dipoles should have the same parameter (the originally passed one and one in
+    # total)
+    assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
+    assert len(list(dipole_initial.parameters())) == 1
+    assert parameter in dipole_initial.parameters()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -158,14 +158,53 @@ def test_dipole_bmadx_tracking(dtype):
 
 
 def test_buffer_registration():
-    """
-    Test that buffers are properly registered in the dipole element.
-    """
+    """Test that buffers are properly registered in the dipole element."""
     length = torch.tensor(0.5)
+    angle = torch.tensor(2e-3)
+    k1 = torch.tensor(1.2)
+    dipole_e1 = torch.tensor(1e-3)
+    dipole_e2 = torch.tensor(-1e-3)
+    tilt = torch.tensor(0.1)
+    gap = torch.tensor(0.1)
     gap_exit = torch.tensor(0.1)
-    dipole = Dipole(length=length, gap_exit=gap_exit)
+    fringe_integral = torch.tensor(0.5)
+    fringe_integral_exit = torch.tensor(0.5)
+    fringe_at = "both"
+    fringe_type = "linear_edge"
+    tracking_method = "cheetah"
+    name = "some_dipole"
 
-    # length and gap_exit are tested because they behave slightly different than other
-    # properties. length is inherited and gap_exit is derived from gap by default.
+    dipole = Dipole(
+        length=length,
+        angle=angle,
+        k1=k1,
+        dipole_e1=dipole_e1,
+        dipole_e2=dipole_e2,
+        tilt=tilt,
+        gap=gap,
+        gap_exit=gap_exit,
+        fringe_integral=fringe_integral,
+        fringe_integral_exit=fringe_integral_exit,
+        fringe_at=fringe_at,
+        fringe_type=fringe_type,
+        tracking_method=tracking_method,
+        name=name,
+    )
+
+    # Should be buffers
     assert length in dipole.buffers()
+    assert angle in dipole.buffers()
+    assert k1 in dipole.buffers()
+    assert dipole_e1 in dipole.buffers()
+    assert dipole_e2 in dipole.buffers()
+    assert tilt in dipole.buffers()
+    assert gap in dipole.buffers()
     assert gap_exit in dipole.buffers()
+    assert fringe_integral in dipole.buffers()
+    assert fringe_integral_exit in dipole.buffers()
+
+    # Should not be buffers
+    assert fringe_at not in dipole.buffers()
+    assert fringe_type not in dipole.buffers()
+    assert tracking_method not in dipole.buffers()
+    assert name not in dipole.buffers()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -155,3 +155,22 @@ def test_dipole_bmadx_tracking(dtype):
         rtol=1e-14 if dtype == torch.float64 else 0.00001,
         atol=1e-14 if dtype == torch.float64 else 1e-6,
     )
+
+
+def test_parameters_at_initialization():
+    """
+    Test that passing a `torch.nn.Parameter` at initialization registeres the
+    parameter in the same way as an assignment after initialization.
+    """
+    param = torch.nn.Parameter(torch.tensor(0.2))
+
+    dipole = Dipole(length=torch.tensor(1.0))
+    dipole_parameter = Dipole(length=torch.tensor(1.0), angle=param)
+
+    assert len(list(dipole.parameters())) == 0
+    dipole.angle = param
+    assert len(list(dipole.parameters())) == 1
+    assert param in dipole.parameters()
+
+    assert len(list(dipole_parameter.parameters())) == 1
+    assert param in dipole_parameter.parameters()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -191,6 +191,9 @@ def test_buffer_registration():
         name=name,
     )
 
+    # Check for expected number of buffers
+    assert len(list(dipole.buffers())) == 10
+
     # Should be buffers
     assert length in dipole.buffers()
     assert angle in dipole.buffers()

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -155,27 +155,3 @@ def test_dipole_bmadx_tracking(dtype):
         rtol=1e-14 if dtype == torch.float64 else 0.00001,
         atol=1e-14 if dtype == torch.float64 else 1e-6,
     )
-
-
-def test_parameters_at_initialization():
-    """
-    Test that passing a `torch.nn.Parameter` at initialization registeres the parameter
-    in the same way as an assignment after initialization.
-    """
-    dipole_with_buffer = Dipole(length=torch.tensor(1.0))
-
-    # Dipole with buffer (without parameter) should not have any parameters
-    assert len(list(dipole_with_buffer.parameters())) == 0
-
-    # Create two dipoles with the same parameter, one passed at initialization and one
-    # assigned after initialization.
-    parameter = torch.nn.Parameter(torch.tensor(0.2))
-    dipole_initial = Dipole(length=torch.tensor(1.0), angle=parameter)
-    dipole_assigned = Dipole(length=torch.tensor(1.0))
-    dipole_assigned.angle = parameter
-
-    # Both dipoles should have the same parameter (the originally passed one and one in
-    # total)
-    assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
-    assert len(list(dipole_initial.parameters())) == 1
-    assert parameter in dipole_initial.parameters()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently, a `torch.nn.Parameter` provided at initialization to Cheetah elements does not appear in the list of parameters returned by `.parameters()`, in contrast to a parameter assigned after initialization. This PR makes the behaviour consistent.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #302 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
