### PR TITLE
Make beam argument mandatory in `Segment.plot_overview`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🚨 Breaking Changes
 
+- `Segment.plot_overview` now requires an incoming `Beam` to be passed, requiring a change in the order of arguments. (see #316) (@Hespe)
+
 ### 🚀 Features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚨 Breaking Changes
 
-- `Segment.plot_overview` now requires an incoming `Beam` to be passed, requiring a change in the order of arguments. (see #316) (@Hespe)
+- The `incoming` argument of `Segment.plot_overview` is no longer optional. This change also affects the order of the arguments. Fixes an exception that was raised by an underlying plot function that requires `incoming` to be set. (see #316) (@Hespe)
 
 ### 🚀 Features
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -494,8 +494,8 @@ class Segment(Element):
 
     def plot_overview(
         self,
+        incoming: Beam,
         fig: Optional[matplotlib.figure.Figure] = None,
-        incoming: Optional[Beam] = None,
         num_particles: int = 10,
         resolution: float = 0.01,
         vector_idx: Optional[tuple] = None,
@@ -503,8 +503,8 @@ class Segment(Element):
         """
         Plot an overview of the segment with the lattice and traced reference particles.
 
-        :param fig: Figure to plot the overview into.
         :param incoming: Entering beam from which the reference particles are sampled.
+        :param fig: Figure to plot the overview into.
         :param num_particles: Number of reference particles to plot. Must not be larger
             than number of particles passed in `beam`.
         :param resolution: Minimum resolution of the tracking of the reference particles


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`Segment.plot_overview` currently marks its `incoming` argument as optional with default `None`. This is misleading, since the function crashes if no `Beam` is passed.

This is a breaking change, since the order of arguments has to be changed to allow for `incoming` to have no default.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #315 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
