### PR TITLE
Make openPMD-beamphysics a truly optional dependency

### DIFF
--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -2,7 +2,6 @@ import itertools
 from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
-import pmd_beamphysics as openpmd
 import torch
 from matplotlib import pyplot as plt
 from scipy import constants
@@ -675,6 +674,14 @@ class ParticleBeam(Beam):
         cls, path: str, energy: torch.Tensor, device=None, dtype=None
     ) -> "ParticleBeam":
         """Load an openPMD particle group HDF5 file as a Cheetah `ParticleBeam`."""
+        try:
+            import pmd_beamphysics as openpmd
+        except ImportError:
+            raise ImportError(
+                """To use the openPMD beam import, openPMD-beamphysics must be
+                installed."""
+            )
+
         particle_group = openpmd.ParticleGroup(path)
         return cls.from_openpmd_particlegroup(
             particle_group, energy, device=device, dtype=dtype
@@ -683,7 +690,7 @@ class ParticleBeam(Beam):
     @classmethod
     def from_openpmd_particlegroup(
         cls,
-        particle_group: openpmd.ParticleGroup,
+        particle_group: "openpmd.ParticleGroup",  # noqa: F821
         energy: torch.Tensor,
         device=None,
         dtype=None,
@@ -729,7 +736,7 @@ class ParticleBeam(Beam):
         particle_group = self.to_openpmd_particlegroup()
         particle_group.write(path)
 
-    def to_openpmd_particlegroup(self) -> openpmd.ParticleGroup:
+    def to_openpmd_particlegroup(self) -> "openpmd.ParticleGroup":  # noqa: F821
         """
         Convert the `ParticleBeam` to an openPMD `ParticleGroup` object.
 
@@ -741,6 +748,14 @@ class ParticleBeam(Beam):
 
         :return: openPMD `ParticleGroup` object with the `ParticleBeam`'s particles.
         """
+        try:
+            import pmd_beamphysics as openpmd
+        except ImportError:
+            raise ImportError(
+                """To use the openPMD beam export, openPMD-beamphysics must be
+                installed."""
+            )
+
         # For now only support non-batched particles
         if len(self.particles.shape) != 2:
             raise ValueError("Only non-batched particles are supported.")

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/cr-xu/ocelot@update-scipy-compatibility # Ocelot
+openpmd-beamphysics
 pytest
 pytest-cov


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

openPMD-beamphysics is marked as an optional dependency, but importing cheetah fails if it is not installed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #319 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
