### PR TITLE
Space charge tests: improve backward-mode test ; add forward-mode test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### 🐆 Other
 
+- The tests for backward-mode differentiation with space charge was improved, by checking the accuracy of the gradients (see #339) (@RemiLehe)
+- A tests for forward-mode differentiation with space charge was added (see #339) (@RemiLehe)
 - Test tolerances were adjusted reduce the chance of random test failures (see #309, #324) (@Hespe, @jank324)
 - The copyright years were updated to 2025 (see #318) (@jank324)
 - The broken institution logo rendering in the documentation has been fixed (see #318) (@jank324)

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -297,7 +297,7 @@ def test_forward_gradient():
     Nb = incoming_beam.total_charge / elementary_charge
     segment_length = beta * gamma * kappa * torch.sqrt(R0**3 / (Nb * electron_radius))
 
-    tangent = torch.rand_like(segment_length)
+    tangent = torch.zeros_like(segment_length)
 
     with fwAD.dual_level():
 

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -13,7 +13,7 @@ def test_cold_uniform_beam_expansion():
     travelling through a drift section with space_charge. (cf ImpactX test:
     https://impactx.readthedocs.io/en/latest/usage/examples/cfchannel/README.html#constant-focusing-channel-with-space-charge)
     See Free Expansion of a Cold Uniform Bunch in
-    https://accelconf.web.cern.ch/hb2023/papers/thbp44.pdf.
+    https://accelconf.web.cern.ch/hb2023/papers/thbp44.pdf
     """
 
     # Simulation parameters
@@ -254,10 +254,12 @@ def test_gradient():
 
     # Compute the gradient of the beam size with respect to the segment length
     # This would throw an error if in-place operations are used
-    beam_size = outgoing_beam.sigma_x.mean()
+    beam_size = outgoing_beam.sigma_x
     beam_size.backward()
-    print(beam_size)
-    print(segment_length.grad)
+    dR_dL = segment_length.grad
+    dR_dL_expected = torch.sqrt((Nb * electron_radius)/R0)/gamma
+    print(dR_dL)
+    print(dR_dL_expected)
 
 
 def test_forward_gradient():
@@ -320,7 +322,7 @@ def test_forward_gradient():
         outgoing_beam = segment.track(incoming_beam)
 
         # Compute the gradient of the beam size with respect to the segment length
-        beam_size = outgoing_beam.sigma_x.mean()
+        beam_size = outgoing_beam.sigma_x
         jvp = fwAD.unpack_dual(beam_size).tangent
         print(jvp)
 

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -11,7 +11,7 @@ def test_cold_uniform_beam_expansion():
     """
     Tests that that a cold uniform beam doubles in size in both dimensions when
     travelling through a drift section with space_charge. (cf ImpactX test:
-    https://impactx.readthedocs.io/en/latest/usage/examples/cfchannel/README.html#constant-focusing-channel-with-space-charge)
+    https://impactx.readthedocs.io/en/latest/usage/examples/expanding_beam/README.html
     See Free Expansion of a Cold Uniform Bunch in
     https://accelconf.web.cern.ch/hb2023/papers/thbp44.pdf
     """

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -256,6 +256,7 @@ def test_gradient():
     # This would throw an error if in-place operations are used
     beam_size = outgoing_beam.sigma_x.mean()
     beam_size.backward()
+    print(beam_size)
     print(segment_length.grad)
 
 
@@ -297,7 +298,7 @@ def test_forward_gradient():
     Nb = incoming_beam.total_charge / elementary_charge
     segment_length = beta * gamma * kappa * torch.sqrt(R0**3 / (Nb * electron_radius))
 
-    tangent = torch.zeros_like(segment_length)
+    tangent = torch.ones_like(segment_length)
 
     with fwAD.dual_level():
 

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -229,6 +229,7 @@ def test_gradient():
     # This would throw an error if in-place operations are used
     beam_size = outgoing_beam.sigma_x.mean()
     beam_size.backward()
+    print(segment_length.grad)
 
 
 def test_forward_gradient():
@@ -263,12 +264,13 @@ def test_forward_gradient():
             ]
         )
 
-    # Track the beam
-    outgoing_beam = segment.track(incoming_beam)
+        # Track the beam
+        outgoing_beam = segment.track(incoming_beam)
 
-    # Compute the gradient of the beam size with respect to the segment length
-    beam_size = outgoing_beam.sigma_x.mean()
-    jvp = fwAD.unpack_dual(beam_size)
+        # Compute the gradient of the beam size with respect to the segment length
+        beam_size = outgoing_beam.sigma_x.mean()
+        jvp = fwAD.unpack_dual(beam_size).tangent
+        print(jvp)
 
 
 def test_does_not_break_segment_length():

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -201,7 +201,7 @@ def test_incoming_beam_not_modified():
 
 def test_gradient():
     """
-    Tests that the gradient of the track method is computed withouth throwing an error.
+    Tests that the gradient of the track method is computed accurately.
     """
 
     # Simulation parameters
@@ -261,8 +261,7 @@ def test_gradient():
 
 def test_forward_gradient():
     """
-    Tests that the gradient of the track method, in forward mode, is computed withouth
-    throwing an error.
+    Tests that the gradient of the track method, in forward mode, is computed accurately.
 
     See: https://pytorch.org/tutorials/intermediate/forward_ad_usage.html
     """

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -261,9 +261,9 @@ def test_gradient():
     # derivative of the beam radius as a function of the segment length
     dsigma_dL = segment_length.grad
     # For a sphere, the radius is sqrt(5) bigger than sigma_x
-    dR_dL = 5**.5 * dsigma_dL
+    dR_dL = 5**0.5 * dsigma_dL
     # Theoretical formula obtained by conservation of energy in the beam frame
-    dR_dL_expected = torch.sqrt((Nb * electron_radius)/R0)/gamma
+    dR_dL_expected = torch.sqrt((Nb * electron_radius) / R0) / gamma
     assert torch.allclose(dR_dL, dR_dL_expected, rtol=0.1)
 
 
@@ -331,9 +331,9 @@ def test_forward_gradient():
         # derivative of the beam radius as a function of the segment length
         dsigma_dL = fwAD.unpack_dual(beam_size).tangent
         # For a sphere, the radius is sqrt(5) bigger than sigma_x
-        dR_dL = 5**.5 * dsigma_dL
+        dR_dL = 5**0.5 * dsigma_dL
         # Theoretical formula obtained by conservation of energy in the beam frame
-        dR_dL_expected = torch.sqrt((Nb * electron_radius)/R0)/gamma
+        dR_dL_expected = torch.sqrt((Nb * electron_radius) / R0) / gamma
         assert torch.allclose(dR_dL, dR_dL_expected, rtol=0.1)
 
 

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -269,7 +269,8 @@ def test_gradient():
 
 def test_forward_gradient():
     """
-    Tests that the gradient of the track method, in forward mode, is computed accurately.
+    Tests that the gradient of the track method,
+    in forward mode, is computed accurately.
 
     See: https://pytorch.org/tutorials/intermediate/forward_ad_usage.html
     """


### PR DESCRIPTION
## Description

This PR improves the space-charge tests:

- It now tests the accuracy of the gradient calculation, for the backward-mode differentiation.
- In addition, it adds a similar test for forward-mode differentiation.

## Motivation and Context

Since Cheetah is built with `pytorch`, it supports backward-differentiation, but also forward differentiation (see [this page](https://pytorch.org/tutorials/intermediate/forward_ad_usage.html)). This could be useful since the scaling of forward differentiation is different from that of backward differentiation. 

In addition, previous tests of backward-differentiation mode were simply checking that the differentiation ran without error, but they did not check the accuracy of the computed gradient. In this PR, we now test the accuracy of the gradient, by reusing the parameters of https://accelconf.web.cern.ch/hb2023/papers/thbp44.pdf, and by using an analytical formula to find the expected gradient.

## Types of changes

New test

## Checklist

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).
