### PR TITLE
Automatically detect default `dtype` for lattice and beam importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add Python 3.13 support (see #275) (@jank324)
 - Methods `to_parameter_beam` and `to_particle_beam` have been added for convenient conversion between `ParticleBeam` and `ParameterBeam` (see #331) (@jank324)
 - Beam classes now have the `mu_tau` and `mu_p` properties on their interfaces (see #331) (@jank324)
+- Lattice and beam converters now adhere to the default torch `dtype` when no explicit `dtype` is passed (see #340) (@Hespe, @jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -64,7 +64,7 @@ class Screen(Element):
             "kde",
         ], f"Invalid method {method}. Must be either 'histogram' or 'kde'."
 
-        self.resolution = resolution
+        self.resolution = (int(resolution[0]), int(resolution[1]))
         self.binning = binning
         self.method = method
         self.is_blocking = is_blocking
@@ -79,7 +79,7 @@ class Screen(Element):
         # torch.Tensor, preventing crashes in some instances.
         self.register_buffer(
             "cached_reading",
-            torch.full((resolution[0], resolution[1]), torch.nan, **factory_kwargs),
+            torch.full(self.resolution, torch.nan, **factory_kwargs),
         )
 
         if pixel_size is not None:
@@ -303,7 +303,7 @@ class Screen(Element):
         # `nn.Module`, and registering it as a submodule of the screen.
         self._read_beam = value
         self.cached_reading = torch.full(
-            (self.resolution[0], self.resolution[1]),
+            self.resolution,
             torch.nan,
             device=self.cached_reading.device,
             dtype=self.cached_reading.dtype,

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -59,6 +59,9 @@ class Screen(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name, **factory_kwargs)
 
+        assert (
+            isinstance(resolution, tuple) and len(resolution) == 2
+        ), "Invalid resolution. Must be a tuple of 2 integers."
         assert method in [
             "histogram",
             "kde",
@@ -74,12 +77,9 @@ class Screen(Element):
         self.register_buffer("misalignment", torch.tensor((0.0, 0.0), **factory_kwargs))
         self.register_buffer("kde_bandwidth", torch.clone(self.pixel_size[0]))
 
-        # NOTE: According to its type hint, the operation on resolution below is a
-        # no-op. However, this form is robust against accidentally passing a
-        # torch.Tensor, preventing crashes in some instances.
         self.register_buffer(
             "cached_reading",
-            torch.full((resolution[0], resolution[1]), torch.nan, **factory_kwargs),
+            torch.full((resolution[1], resolution[0]), torch.nan, **factory_kwargs),
         )
 
         if pixel_size is not None:

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -64,7 +64,7 @@ class Screen(Element):
             "kde",
         ], f"Invalid method {method}. Must be either 'histogram' or 'kde'."
 
-        self.resolution = (int(resolution[0]), int(resolution[1]))
+        self.resolution = resolution
         self.binning = binning
         self.method = method
         self.is_blocking = is_blocking
@@ -79,7 +79,7 @@ class Screen(Element):
         # torch.Tensor, preventing crashes in some instances.
         self.register_buffer(
             "cached_reading",
-            torch.full(self.resolution, torch.nan, **factory_kwargs),
+            torch.full((resolution[0], resolution[1]), torch.nan, **factory_kwargs),
         )
 
         if pixel_size is not None:
@@ -303,7 +303,7 @@ class Screen(Element):
         # `nn.Module`, and registering it as a submodule of the screen.
         self._read_beam = value
         self.cached_reading = torch.full(
-            self.resolution,
+            (self.resolution[0], self.resolution[1]),
             torch.nan,
             device=self.cached_reading.device,
             dtype=self.cached_reading.dtype,

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import matplotlib.pyplot as plt
 import torch
@@ -41,7 +41,7 @@ class Screen(Element):
 
     def __init__(
         self,
-        resolution: tuple[int, int] = (1024, 1024),
+        resolution: Union[tuple[int, int], list[int]] = (1024, 1024),
         pixel_size: Optional[torch.Tensor] = None,
         binning: int = 1,
         misalignment: Optional[torch.Tensor] = None,
@@ -60,7 +60,7 @@ class Screen(Element):
         super().__init__(name=name, **factory_kwargs)
 
         assert (
-            isinstance(resolution, tuple) and len(resolution) == 2
+            isinstance(resolution, (tuple, list)) and len(resolution) == 2
         ), "Invalid resolution. Must be a tuple of 2 integers."
         assert method in [
             "histogram",

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -280,8 +280,8 @@ class Segment(Element):
         cls,
         bmad_lattice_file_path: str,
         environment_variables: Optional[dict] = None,
-        device: Optional[Union[str, torch.device]] = None,
-        dtype: torch.dtype = torch.float32,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
     ) -> "Segment":
         """
         Read a Cheetah segment from a Bmad lattice file.
@@ -308,8 +308,8 @@ class Segment(Element):
         cls,
         elegant_lattice_file_path: str,
         name: str,
-        device: Optional[Union[str, torch.device]] = None,
-        dtype: torch.dtype = torch.float32,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
     ) -> "Segment":
         """
         Read a Cheetah segment from an elegant lattice file.

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -213,14 +213,21 @@ class Segment(Element):
         )
 
     @classmethod
-    def from_lattice_json(cls, filepath: str) -> "Segment":
+    def from_lattice_json(
+        cls,
+        filepath: str,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> "Segment":
         """
         Load a Cheetah model from a JSON file.
 
-        :param filename: Name/path of the file to load the lattice from.
+        :param filepath: Path of the file to load the lattice from.
+        :param device: Device to place the lattice elements on.
+        :param dtype: Data type to use for the lattice elements.
         :return: Loaded Cheetah `Segment`.
         """
-        return load_cheetah_model(filepath)
+        return load_cheetah_model(filepath, device=device, dtype=dtype)
 
     def to_lattice_json(
         self,
@@ -263,6 +270,8 @@ class Segment(Element):
         :param name: Unique identifier for the entire segment.
         :param warnings: Whether to print warnings when objects are not supported by
             Cheetah or converted with potentially unexpected behavior.
+        :param device: Device to place the lattice elements on.
+        :param dtype: Data type to use for the lattice elements.
         :return: Cheetah segment closely resembling the Ocelot cell.
         """
         from cheetah.converters import ocelot

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -246,8 +246,8 @@ class Segment(Element):
         cell,
         name: Optional[str] = None,
         warnings: bool = True,
-        device=None,
-        dtype=torch.float32,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
         **kwargs,
     ) -> "Segment":
         """

--- a/cheetah/converters/astra.py
+++ b/cheetah/converters/astra.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 from scipy.constants import physical_constants
 
@@ -7,7 +5,7 @@ from scipy.constants import physical_constants
 electron_mass_eV = physical_constants["electron mass energy equivalent in MeV"][0] * 1e6
 
 
-def from_astrabeam(path: str) -> Tuple[np.ndarray, float, np.ndarray]:
+def from_astrabeam(path: str) -> tuple[np.ndarray, float, np.ndarray]:
     """
     Read from a ASTRA beam distribution, and prepare for conversion to a Cheetah
     ParticleBeam or ParameterBeam.

--- a/cheetah/converters/astra.py
+++ b/cheetah/converters/astra.py
@@ -39,7 +39,7 @@ def from_astrabeam(path: str) -> tuple[np.ndarray, float, np.ndarray]:
     energy = gamref * electron_mass_eV
 
     n_particles = xp.shape[0]
-    particles = np.zeros((n_particles, 6), dtype=P0.dtype)
+    particles = np.zeros((n_particles, 6))
 
     u = np.c_[xp[:, 3], xp[:, 4], xp[:, 5] + Pref]
     gamma = np.sqrt(1 + np.sum(u * u, 1) / electron_mass_eV**2)

--- a/cheetah/converters/astra.py
+++ b/cheetah/converters/astra.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from scipy.constants import physical_constants
 
@@ -5,7 +7,7 @@ from scipy.constants import physical_constants
 electron_mass_eV = physical_constants["electron mass energy equivalent in MeV"][0] * 1e6
 
 
-def from_astrabeam(path: str) -> tuple[np.ndarray, float, np.ndarray]:
+def from_astrabeam(path: str) -> Tuple[np.ndarray, float, np.ndarray]:
     """
     Read from a ASTRA beam distribution, and prepare for conversion to a Cheetah
     ParticleBeam or ParameterBeam.
@@ -39,7 +41,7 @@ def from_astrabeam(path: str) -> tuple[np.ndarray, float, np.ndarray]:
     energy = gamref * electron_mass_eV
 
     n_particles = xp.shape[0]
-    particles = np.zeros((n_particles, 6))
+    particles = np.zeros((n_particles, 6), dtype=P0.dtype)
 
     u = np.c_[xp[:, 3], xp[:, 4], xp[:, 5] + Pref]
     gamma = np.sqrt(1 + np.sum(u * u, 1) / electron_mass_eV**2)

--- a/cheetah/converters/bmad.py
+++ b/cheetah/converters/bmad.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import torch
@@ -17,8 +17,8 @@ from cheetah.converters.utils.fortran_namelist import (
 def convert_element(
     name: str,
     context: dict,
-    device: Optional[Union[str, torch.device]] = None,
-    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> "cheetah.Element":
     """Convert a parsed Bmad element dict to a cheetah Element.
 
@@ -26,10 +26,12 @@ def convert_element(
     :param context: Context dictionary parsed from Bmad lattice file(s).
     :param device: Device to put the element on. If `None`, the device is set to
         `torch.device("cpu")`.
-    :param dtype: Data type to use for the element. Default is `torch.float32`.
+    :param dtype: Data type to use for the element. If `None`, the default is determined
+        from `torch.get_default_dtype()`.
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
+    factory_kwargs = {"device": device, "dtype": dtype}
     bmad_parsed = context[name]
 
     if isinstance(bmad_parsed, list):
@@ -60,10 +62,9 @@ def convert_element(
             )
             if "l" in bmad_parsed:
                 return cheetah.Drift(
-                    length=torch.tensor(bmad_parsed["l"]),
+                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                     name=name,
-                    device=device,
-                    dtype=dtype,
+                    **factory_kwargs,
                 )
             else:
                 return cheetah.Marker(name=name)
@@ -73,10 +74,9 @@ def convert_element(
             )
             if "l" in bmad_parsed:
                 return cheetah.Drift(
-                    length=torch.tensor(bmad_parsed["l"]),
+                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                     name=name,
-                    device=device,
-                    dtype=dtype,
+                    **factory_kwargs,
                 )
             else:
                 return cheetah.Marker(name=name)
@@ -85,42 +85,38 @@ def convert_element(
                 ["element_type", "alias", "type", "l", "descrip"], bmad_parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(bmad_parsed["l"]),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "drift":
             validate_understood_properties(
                 ["element_type", "l", "type", "descrip"], bmad_parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(bmad_parsed["l"]),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "hkicker":
             validate_understood_properties(
                 ["element_type", "type", "alias"], bmad_parsed
             )
             return cheetah.HorizontalCorrector(
-                length=torch.tensor(bmad_parsed.get("l", 0.0)),
-                angle=torch.tensor(bmad_parsed.get("kick", 0.0)),
+                length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
+                angle=torch.tensor(bmad_parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "vkicker":
             validate_understood_properties(
                 ["element_type", "type", "alias"], bmad_parsed
             )
             return cheetah.VerticalCorrector(
-                length=torch.tensor(bmad_parsed.get("l", 0.0)),
-                angle=torch.tensor(bmad_parsed.get("kick", 0.0)),
+                length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
+                angle=torch.tensor(bmad_parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "sbend":
             validate_understood_properties(
@@ -143,21 +139,22 @@ def convert_element(
                 bmad_parsed,
             )
             return cheetah.Dipole(
-                length=torch.tensor(bmad_parsed["l"]),
-                gap=torch.tensor(2 * bmad_parsed.get("hgap", 0.0)),
-                angle=torch.tensor(bmad_parsed.get("angle", 0.0)),
-                dipole_e1=torch.tensor(bmad_parsed["e1"]),
-                dipole_e2=torch.tensor(bmad_parsed.get("e2", 0.0)),
-                tilt=torch.tensor(bmad_parsed.get("ref_tilt", 0.0)),
-                fringe_integral=torch.tensor(bmad_parsed.get("fint", 0.0)),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
+                gap=torch.tensor(2 * bmad_parsed.get("hgap", 0.0), **factory_kwargs),
+                angle=torch.tensor(bmad_parsed.get("angle", 0.0), **factory_kwargs),
+                dipole_e1=torch.tensor(bmad_parsed["e1"], **factory_kwargs),
+                dipole_e2=torch.tensor(bmad_parsed.get("e2", 0.0), **factory_kwargs),
+                tilt=torch.tensor(bmad_parsed.get("ref_tilt", 0.0), **factory_kwargs),
+                fringe_integral=torch.tensor(
+                    bmad_parsed.get("fint", 0.0), **factory_kwargs
+                ),
                 fringe_integral_exit=(
-                    torch.tensor(bmad_parsed["fintx"])
+                    torch.tensor(bmad_parsed["fintx"], **factory_kwargs)
                     if "fintx" in bmad_parsed
                     else None
                 ),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "quadrupole":
             # TODO: Aperture for quadrupoles?
@@ -166,23 +163,21 @@ def convert_element(
                 bmad_parsed,
             )
             return cheetah.Quadrupole(
-                length=torch.tensor(bmad_parsed["l"]),
-                k1=torch.tensor(bmad_parsed["k1"]),
-                tilt=torch.tensor(bmad_parsed.get("tilt", 0.0)),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
+                k1=torch.tensor(bmad_parsed["k1"], **factory_kwargs),
+                tilt=torch.tensor(bmad_parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "solenoid":
             validate_understood_properties(
                 ["element_type", "l", "ks", "alias"], bmad_parsed
             )
             return cheetah.Solenoid(
-                length=torch.tensor(bmad_parsed["l"]),
-                k=torch.tensor(bmad_parsed["ks"]),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
+                k=torch.tensor(bmad_parsed["ks"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "lcavity":
             validate_understood_properties(
@@ -200,15 +195,15 @@ def convert_element(
                 bmad_parsed,
             )
             return cheetah.Cavity(
-                length=torch.tensor(bmad_parsed["l"]),
-                voltage=torch.tensor(bmad_parsed.get("voltage", 0.0)),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
+                voltage=torch.tensor(bmad_parsed.get("voltage", 0.0), **factory_kwargs),
                 phase=torch.tensor(
-                    -np.degrees(bmad_parsed.get("phi0", 0.0) * 2 * np.pi)
+                    -np.degrees(bmad_parsed.get("phi0", 0.0) * 2 * np.pi),
+                    **factory_kwargs,
                 ),
-                frequency=torch.tensor(bmad_parsed["rf_frequency"]),
+                frequency=torch.tensor(bmad_parsed["rf_frequency"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "rcollimator":
             validate_understood_properties(
@@ -218,18 +213,22 @@ def convert_element(
             return cheetah.Segment(
                 elements=[
                     cheetah.Drift(
-                        length=torch.tensor(bmad_parsed.get("l", 0.0)),
+                        length=torch.tensor(
+                            bmad_parsed.get("l", 0.0), **factory_kwargs
+                        ),
                         name=name + "_drift",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
-                        x_max=torch.tensor(bmad_parsed.get("x_limit", np.inf)),
-                        y_max=torch.tensor(bmad_parsed.get("y_limit", np.inf)),
+                        x_max=torch.tensor(
+                            bmad_parsed.get("x_limit", np.inf), **factory_kwargs
+                        ),
+                        y_max=torch.tensor(
+                            bmad_parsed.get("y_limit", np.inf), **factory_kwargs
+                        ),
                         shape="rectangular",
                         name=name + "_aperture",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                 ],
                 name=name,
@@ -242,18 +241,22 @@ def convert_element(
             return cheetah.Segment(
                 elements=[
                     cheetah.Drift(
-                        length=torch.tensor(bmad_parsed.get("l", 0.0)),
+                        length=torch.tensor(
+                            bmad_parsed.get("l", 0.0), **factory_kwargs
+                        ),
                         name=name + "_drift",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
-                        x_max=torch.tensor(bmad_parsed.get("x_limit", np.inf)),
-                        y_max=torch.tensor(bmad_parsed.get("y_limit", np.inf)),
+                        x_max=torch.tensor(
+                            bmad_parsed.get("x_limit", np.inf), **factory_kwargs
+                        ),
+                        y_max=torch.tensor(
+                            bmad_parsed.get("y_limit", np.inf), **factory_kwargs
+                        ),
                         shape="elliptical",
                         name=name + "_aperture",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                 ],
             )
@@ -273,19 +276,17 @@ def convert_element(
                 bmad_parsed,
             )
             return cheetah.Undulator(
-                length=torch.tensor(bmad_parsed["l"]),
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "patch":
             # TODO: Does this need to be implemented in Cheetah in a more proper way?
             validate_understood_properties(["element_type", "tilt"], bmad_parsed)
             return cheetah.Drift(
-                length=torch.tensor(bmad_parsed.get("l", 0.0)),
+                length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         else:
             print(
@@ -295,9 +296,8 @@ def convert_element(
             # TODO: Remove the length if by adding markers to Cheeath
             return cheetah.Drift(
                 name=name,
-                length=torch.tensor(bmad_parsed.get("l", 0.0)),
-                device=device,
-                dtype=dtype,
+                length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
+                **factory_kwargs,
             )
     else:
         raise ValueError(f"Unknown Bmad element type for {name = }")  # noqa: E202, E251
@@ -306,8 +306,8 @@ def convert_element(
 def convert_lattice_to_cheetah(
     bmad_lattice_file_path: Path,
     environment_variables: Optional[dict] = None,
-    device: Optional[Union[str, torch.device]] = None,
-    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> "cheetah.Element":
     """
     Convert a Bmad lattice file to a Cheetah `Segment`.
@@ -322,7 +322,8 @@ def convert_lattice_to_cheetah(
         parsing the lattice file.
     :param device: Device to use for the lattice. If `None`, the device is set to
         `torch.device("cpu")`.
-    :param dtype: Data type to use for the lattice. Default is `torch.float32`.
+    :param dtype: Data type to use for the lattice. If `None`, the default is determined
+        from `torch.get_default_dtype()`.
     :return: Cheetah `Segment` representing the Bmad lattice.
     """
 

--- a/cheetah/converters/bmad.py
+++ b/cheetah/converters/bmad.py
@@ -30,7 +30,10 @@ def convert_element(
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
-    factory_kwargs = {"device": device, "dtype": dtype}
+    factory_kwargs = {
+        "device": device,
+        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+    }
     bmad_parsed = context[name]
 
     if isinstance(bmad_parsed, list):

--- a/cheetah/converters/bmad.py
+++ b/cheetah/converters/bmad.py
@@ -62,9 +62,7 @@ def convert_element(
             )
             if "l" in bmad_parsed:
                 return cheetah.Drift(
-                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
-                    name=name,
-                    **factory_kwargs,
+                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs), name=name
                 )
             else:
                 return cheetah.Marker(name=name)
@@ -74,9 +72,7 @@ def convert_element(
             )
             if "l" in bmad_parsed:
                 return cheetah.Drift(
-                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
-                    name=name,
-                    **factory_kwargs,
+                    length=torch.tensor(bmad_parsed["l"], **factory_kwargs), name=name
                 )
             else:
                 return cheetah.Marker(name=name)
@@ -85,18 +81,14 @@ def convert_element(
                 ["element_type", "alias", "type", "l", "descrip"], bmad_parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs), name=name
             )
         elif bmad_parsed["element_type"] == "drift":
             validate_understood_properties(
                 ["element_type", "l", "type", "descrip"], bmad_parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs), name=name
             )
         elif bmad_parsed["element_type"] == "hkicker":
             validate_understood_properties(
@@ -106,7 +98,6 @@ def convert_element(
                 length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(bmad_parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "vkicker":
             validate_understood_properties(
@@ -116,7 +107,6 @@ def convert_element(
                 length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(bmad_parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "sbend":
             validate_understood_properties(
@@ -154,7 +144,6 @@ def convert_element(
                     else None
                 ),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "quadrupole":
             # TODO: Aperture for quadrupoles?
@@ -167,7 +156,6 @@ def convert_element(
                 k1=torch.tensor(bmad_parsed["k1"], **factory_kwargs),
                 tilt=torch.tensor(bmad_parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "solenoid":
             validate_understood_properties(
@@ -177,7 +165,6 @@ def convert_element(
                 length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                 k=torch.tensor(bmad_parsed["ks"], **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "lcavity":
             validate_understood_properties(
@@ -203,7 +190,6 @@ def convert_element(
                 ),
                 frequency=torch.tensor(bmad_parsed["rf_frequency"], **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif bmad_parsed["element_type"] == "rcollimator":
             validate_understood_properties(
@@ -217,7 +203,6 @@ def convert_element(
                             bmad_parsed.get("l", 0.0), **factory_kwargs
                         ),
                         name=name + "_drift",
-                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
@@ -228,7 +213,6 @@ def convert_element(
                         ),
                         shape="rectangular",
                         name=name + "_aperture",
-                        **factory_kwargs,
                     ),
                 ],
                 name=name,
@@ -245,7 +229,6 @@ def convert_element(
                             bmad_parsed.get("l", 0.0), **factory_kwargs
                         ),
                         name=name + "_drift",
-                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
@@ -256,7 +239,6 @@ def convert_element(
                         ),
                         shape="elliptical",
                         name=name + "_aperture",
-                        **factory_kwargs,
                     ),
                 ],
             )
@@ -276,9 +258,7 @@ def convert_element(
                 bmad_parsed,
             )
             return cheetah.Undulator(
-                length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(bmad_parsed["l"], **factory_kwargs), name=name
             )
         elif bmad_parsed["element_type"] == "patch":
             # TODO: Does this need to be implemented in Cheetah in a more proper way?
@@ -286,7 +266,6 @@ def convert_element(
             return cheetah.Drift(
                 length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         else:
             print(
@@ -295,9 +274,8 @@ def convert_element(
             )
             # TODO: Remove the length if by adding markers to Cheeath
             return cheetah.Drift(
-                name=name,
                 length=torch.tensor(bmad_parsed.get("l", 0.0), **factory_kwargs),
-                **factory_kwargs,
+                name=name,
             )
     else:
         raise ValueError(f"Unknown Bmad element type for {name = }")  # noqa: E202, E251

--- a/cheetah/converters/bmad.py
+++ b/cheetah/converters/bmad.py
@@ -23,16 +23,16 @@ def convert_element(
 
     :param name: Name of the (top-level) element to convert.
     :param context: Context dictionary parsed from Bmad lattice file(s).
-    :param device: Device to put the element on. If `None`, the device is set to
-        `torch.device("cpu")`.
-    :param dtype: Data type to use for the element. If `None`, the default is determined
-        from `torch.get_default_dtype()`.
+    :param device: Device to put the element on. If `None`, the current default device
+        of PyTorch is used.
+    :param dtype: Data type to use for the element. If `None`, the current default dtype
+        of PyTorch is used.
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
     factory_kwargs = {
-        "device": device,
-        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+        "device": device or torch.get_default_device(),
+        "dtype": dtype or torch.get_default_dtype(),
     }
     bmad_parsed = context[name]
 
@@ -300,10 +300,10 @@ def convert_lattice_to_cheetah(
     :param bmad_lattice_file_path: Path to the Bmad lattice file.
     :param environment_variables: Dictionary of environment variables to use when
         parsing the lattice file.
-    :param device: Device to use for the lattice. If `None`, the device is set to
-        `torch.device("cpu")`.
-    :param dtype: Data type to use for the lattice. If `None`, the default is determined
-        from `torch.get_default_dtype()`.
+    :param device: Device to use for the lattice. If `None`, the current default device
+        of PyTorch is used.
+    :param dtype: Data type to use for the lattice. If `None`, the current default dtype
+        of PyTorch is used.
     :return: Cheetah `Segment` representing the Bmad lattice.
     """
 

--- a/cheetah/converters/bmad.py
+++ b/cheetah/converters/bmad.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
 import torch
 
 import cheetah
@@ -185,7 +184,7 @@ def convert_element(
                 length=torch.tensor(bmad_parsed["l"], **factory_kwargs),
                 voltage=torch.tensor(bmad_parsed.get("voltage", 0.0), **factory_kwargs),
                 phase=torch.tensor(
-                    -np.degrees(bmad_parsed.get("phi0", 0.0) * 2 * np.pi),
+                    -torch.rad2deg(bmad_parsed.get("phi0", 0.0) * 2 * torch.pi),
                     **factory_kwargs,
                 ),
                 frequency=torch.tensor(bmad_parsed["rf_frequency"], **factory_kwargs),
@@ -206,10 +205,10 @@ def convert_element(
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
-                            bmad_parsed.get("x_limit", np.inf), **factory_kwargs
+                            bmad_parsed.get("x_limit", torch.inf), **factory_kwargs
                         ),
                         y_max=torch.tensor(
-                            bmad_parsed.get("y_limit", np.inf), **factory_kwargs
+                            bmad_parsed.get("y_limit", torch.inf), **factory_kwargs
                         ),
                         shape="rectangular",
                         name=name + "_aperture",
@@ -232,10 +231,10 @@ def convert_element(
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
-                            bmad_parsed.get("x_limit", np.inf), **factory_kwargs
+                            bmad_parsed.get("x_limit", torch.inf), **factory_kwargs
                         ),
                         y_max=torch.tensor(
-                            bmad_parsed.get("y_limit", np.inf), **factory_kwargs
+                            bmad_parsed.get("y_limit", torch.inf), **factory_kwargs
                         ),
                         shape="elliptical",
                         name=name + "_aperture",

--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -29,7 +29,10 @@ def convert_element(
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
-    factory_kwargs = {"device": device, "dtype": dtype}
+    factory_kwargs = {
+        "device": device,
+        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+    }
     parsed = context[name]
 
     if isinstance(parsed, list):

--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -15,8 +15,8 @@ from cheetah.converters.utils.fortran_namelist import (
 def convert_element(
     name: str,
     context: dict,
-    device: Optional[Union[str, torch.device]] = None,
-    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> "cheetah.Element":
     """Convert a parsed elegant element dict to a cheetah Element.
 
@@ -24,10 +24,12 @@ def convert_element(
     :param context: Context dictionary parsed from elegant lattice file(s).
     :param device: Device to put the element on. If `None`, the device is set to
         `torch.device("cpu")`.
-    :param dtype: Data type to use for the element. Default is `torch.float32`.
+    :param dtype: Data type to use for the element. If `None`, the default is determined
+        from `torch.get_default_dtype()`.
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
+    factory_kwargs = {"device": device, "dtype": dtype}
     parsed = context[name]
 
     if isinstance(parsed, list):
@@ -43,32 +45,29 @@ def convert_element(
             # The group property does not have an analoge in Cheetah, so it is neglected
             validate_understood_properties(["element_type", "l", "group"], parsed)
             return cheetah.Solenoid(
-                length=torch.tensor(parsed["l"]),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["hkick", "hkic"]:
             validate_understood_properties(
                 ["element_type", "l", "kick", "group"], parsed
             )
             return cheetah.HorizontalCorrector(
-                length=torch.tensor(parsed.get("l", 0.0)),
-                angle=torch.tensor(parsed.get("kick", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
+                angle=torch.tensor(parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["vkick", "vkic"]:
             validate_understood_properties(
                 ["element_type", "l", "kick", "group"], parsed
             )
             return cheetah.VerticalCorrector(
-                length=torch.tensor(parsed.get("l", 0.0)),
-                angle=torch.tensor(parsed.get("kick", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
+                angle=torch.tensor(parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["mark", "marker"]:
             validate_understood_properties(["element_type", "group"], parsed)
@@ -78,18 +77,16 @@ def convert_element(
 
             # TODO Find proper element class
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["drift", "drif"]:
             validate_understood_properties(["element_type", "l", "group"], parsed)
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["csrdrift", "csrdrif"]:
             # Drift that includes effects from coherent synchrotron radiation
@@ -97,10 +94,9 @@ def convert_element(
                 ["element_type", "l", "group", "use_stupakov", "n_kicks", "csr"], parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["lscdrift", "lscdrif"]:
             # Drift that includes space charge effects
@@ -119,10 +115,9 @@ def convert_element(
                 parsed,
             )
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0)),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "ecol":
             validate_understood_properties(
@@ -132,18 +127,20 @@ def convert_element(
             return cheetah.Segment(
                 elements=[
                     cheetah.Drift(
-                        length=torch.tensor(parsed.get("l", 0.0)),
+                        length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                         name=name + "_drift",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
-                        x_max=torch.tensor(parsed.get("x_max", torch.inf)),
-                        y_max=torch.tensor(parsed.get("y_max", torch.inf)),
+                        x_max=torch.tensor(
+                            parsed.get("x_max", torch.inf), **factory_kwargs
+                        ),
+                        y_max=torch.tensor(
+                            parsed.get("y_max", torch.inf), **factory_kwargs
+                        ),
                         shape="elliptical",
                         name=name + "_aperture",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                 ],
                 name=name + "_segment",
@@ -156,18 +153,20 @@ def convert_element(
             return cheetah.Segment(
                 elements=[
                     cheetah.Drift(
-                        length=torch.tensor(parsed.get("l", 0.0)),
+                        length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                         name=name + "_drift",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
-                        x_max=torch.tensor(parsed.get("x_max", torch.inf)),
-                        y_max=torch.tensor(parsed.get("y_max", torch.inf)),
+                        x_max=torch.tensor(
+                            parsed.get("x_max", torch.inf), **factory_kwargs
+                        ),
+                        y_max=torch.tensor(
+                            parsed.get("y_max", torch.inf), **factory_kwargs
+                        ),
                         shape="rectangular",
                         name=name + "_aperture",
-                        device=device,
-                        dtype=dtype,
+                        **factory_kwargs,
                     ),
                 ],
                 name=name + "_segment",
@@ -178,25 +177,11 @@ def convert_element(
                 parsed,
             )
             return cheetah.Quadrupole(
-                length=torch.tensor(parsed["l"]),
-                k1=torch.tensor(parsed["k1"]),
-                tilt=torch.tensor(parsed.get("tilt", 0.0)),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
+                k1=torch.tensor(parsed["k1"], **factory_kwargs),
+                tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
-            )
-        elif parsed["element_type"] == "sext":
-            # validate_understood_properties(
-            #     ["element_type", "l", "group"],
-            #     parsed,
-            # )
-
-            # TODO Parse properly! Missing element class
-            return cheetah.Drift(
-                length=torch.tensor(parsed["l"]),
-                name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "moni":
             validate_understood_properties(["element_type", "group", "l"], parsed)
@@ -204,17 +189,15 @@ def convert_element(
                 return cheetah.Segment(
                     elements=[
                         cheetah.Drift(
-                            length=torch.tensor(parsed["l"] / 2),
+                            length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
                             name=name + "_predrift",
-                            device=device,
-                            dtype=dtype,
+                            **factory_kwargs,
                         ),
                         cheetah.BPM(name=name),
                         cheetah.Drift(
-                            length=torch.tensor(parsed["l"] / 2),
+                            length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
                             name=name + "_postdrift",
-                            device=device,
-                            dtype=dtype,
+                            **factory_kwargs,
                         ),
                     ],
                     name=name + "_segment",
@@ -231,29 +214,26 @@ def convert_element(
                 raise ValueError("Only first order modelling is supported")
 
             # Initially zero in elegant by convention
-            R = torch.zeros((7, 7), device=device, dtype=dtype)
+            R = torch.zeros((7, 7), **factory_kwargs)
             # Add linear component
             R[:6, :6] = torch.tensor(
                 [
                     [parsed.get(f"r{i + 1}{j + 1}", 0.0) for j in range(6)]
                     for i in range(6)
                 ],
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
             # Add affine component (constant offset)
             R[:6, 6] = torch.tensor(
                 [parsed.get(f"c{i + 1}", 0.0) for i in range(6)],
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
 
             return cheetah.CustomTransferMap(
-                length=torch.tensor(parsed["l"]),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
                 predefined_transfer_map=R,
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfca":
             validate_understood_properties(
@@ -274,15 +254,14 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.Cavity(
-                length=torch.tensor(parsed["l"]),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90),
-                voltage=torch.tensor(parsed["volt"]),
-                frequency=torch.tensor(parsed["freq"]),
+                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed["volt"], **factory_kwargs),
+                frequency=torch.tensor(parsed["freq"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfcw":
             validate_understood_properties(
@@ -318,15 +297,14 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.Cavity(
-                length=torch.tensor(parsed["l"]),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90),
-                voltage=torch.tensor(parsed["volt"]),
-                frequency=torch.tensor(parsed["freq"]),
+                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed["volt"], **factory_kwargs),
+                frequency=torch.tensor(parsed["freq"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfdf":
             validate_understood_properties(
@@ -343,15 +321,14 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.TransverseDeflectingCavity(
-                length=torch.tensor(parsed["l"]),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90),
-                voltage=torch.tensor(parsed["voltage"]),
-                frequency=torch.tensor(parsed["frequency"]),
+                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed["voltage"], **factory_kwargs),
+                frequency=torch.tensor(parsed["frequency"], **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] in ["sben", "csbend"]:
             validate_understood_properties(
@@ -359,15 +336,14 @@ def convert_element(
                 parsed,
             )
             return cheetah.Dipole(
-                length=torch.tensor(parsed["l"]),
-                angle=torch.tensor(parsed.get("angle", 0.0)),
-                k1=torch.tensor(parsed.get("k1", 0.0)),
-                dipole_e1=torch.tensor(parsed.get("e1", 0.0)),
-                dipole_e2=torch.tensor(parsed.get("e2", 0.0)),
-                tilt=torch.tensor(parsed.get("tilt", 0.0)),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
+                angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
+                k1=torch.tensor(parsed.get("k1", 0.0), **factory_kwargs),
+                dipole_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),
+                dipole_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
+                tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "rben":
             validate_understood_properties(
@@ -375,14 +351,13 @@ def convert_element(
                 parsed,
             )
             return cheetah.RBend(
-                length=torch.tensor(parsed["l"]),
-                angle=torch.tensor(parsed.get("angle", 0.0)),
-                rbend_e1=torch.tensor(parsed.get("e1", 0.0)),
-                rbend_e2=torch.tensor(parsed.get("e2", 0.0)),
-                tilt=torch.tensor(parsed.get("tilt", 0.0)),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
+                angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
+                rbend_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),
+                rbend_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
+                tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "csrcsben":
             validate_understood_properties(
@@ -410,15 +385,14 @@ def convert_element(
                 parsed,
             )
             return cheetah.Dipole(
-                length=torch.tensor(parsed["l"]),
-                angle=torch.tensor(parsed.get("angle", 0.0)),
-                k1=torch.tensor(parsed.get("k1", 0.0)),
-                dipole_e1=torch.tensor(parsed.get("e1", 0.0)),
-                dipole_e2=torch.tensor(parsed.get("e2", 0.0)),
-                tilt=torch.tensor(parsed.get("tilt", 0.0)),
+                length=torch.tensor(parsed["l"], **factory_kwargs),
+                angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
+                k1=torch.tensor(parsed.get("k1", 0.0), **factory_kwargs),
+                dipole_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),
+                dipole_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
+                tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                device=device,
-                dtype=dtype,
+                **factory_kwargs,
             )
         elif parsed["element_type"] == "watch":
             validate_understood_properties(
@@ -440,9 +414,8 @@ def convert_element(
             # TODO: Remove the length if by adding markers to Cheetah
             return cheetah.Drift(
                 name=name,
-                length=torch.tensor(parsed.get("l", 0.0)),
-                device=device,
-                dtype=dtype,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
+                **factory_kwargs,
             )
     else:
         raise ValueError(
@@ -453,8 +426,8 @@ def convert_element(
 def convert_lattice_to_cheetah(
     elegant_lattice_file_path: Path,
     name: str,
-    device: Optional[Union[str, torch.device]] = None,
-    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> "cheetah.Element":
     """
     Convert a elegant lattice file to a Cheetah `Segment`.
@@ -463,7 +436,8 @@ def convert_lattice_to_cheetah(
     :param name: Name of the root element.
     :param device: Device to use for the lattice. If `None`, the device is set to
         `torch.device("cpu")`.
-    :param dtype: Data type to use for the lattice. Default is `torch.float32`.
+    :param dtype: Data type to use for the lattice. If `None`, the default is determined
+        from `torch.get_default_dtype()`.
     :return: Cheetah `Segment` representing the elegant lattice.
     """
 

--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -22,16 +22,16 @@ def convert_element(
 
     :param name: Name of the (top-level) element to convert.
     :param context: Context dictionary parsed from elegant lattice file(s).
-    :param device: Device to put the element on. If `None`, the device is set to
-        `torch.device("cpu")`.
-    :param dtype: Data type to use for the element. If `None`, the default is determined
-        from `torch.get_default_dtype()`.
+    :param device: Device to use for the lattice. If `None`, the current default device
+        of PyTorch is used.
+    :param dtype: Data type to use for the lattice. If `None`, the current default dtype
+        of PyTorch is used.
     :return: Converted cheetah Element. If you are calling this function yourself
         as a user of Cheetah, this is most likely a `Segment`.
     """
     factory_kwargs = {
-        "device": device,
-        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+        "device": device or torch.get_default_device(),
+        "dtype": dtype or torch.get_default_dtype(),
     }
     parsed = context[name]
 
@@ -409,10 +409,10 @@ def convert_lattice_to_cheetah(
 
     :param elegant_lattice_file_path: Path to the elegant lattice file.
     :param name: Name of the root element.
-    :param device: Device to use for the lattice. If `None`, the device is set to
-        `torch.device("cpu")`.
-    :param dtype: Data type to use for the lattice. If `None`, the default is determined
-        from `torch.get_default_dtype()`.
+    :param device: Device to use for the lattice. If `None`, the current default device
+        of PyTorch is used.
+    :param dtype: Data type to use for the lattice. If `None`, the current default dtype
+        of PyTorch is used.
     :return: Cheetah `Segment` representing the elegant lattice.
     """
 

--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -45,9 +45,7 @@ def convert_element(
             # The group property does not have an analoge in Cheetah, so it is neglected
             validate_understood_properties(["element_type", "l", "group"], parsed)
             return cheetah.Solenoid(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(parsed["l"], **factory_kwargs), name=name
             )
         elif parsed["element_type"] in ["hkick", "hkic"]:
             validate_understood_properties(
@@ -57,7 +55,6 @@ def convert_element(
                 length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] in ["vkick", "vkic"]:
             validate_understood_properties(
@@ -67,7 +64,6 @@ def convert_element(
                 length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(parsed.get("kick", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] in ["mark", "marker"]:
             validate_understood_properties(["element_type", "group"], parsed)
@@ -77,16 +73,12 @@ def convert_element(
 
             # TODO Find proper element class
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
         elif parsed["element_type"] in ["drift", "drif"]:
             validate_understood_properties(["element_type", "l", "group"], parsed)
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
         elif parsed["element_type"] in ["csrdrift", "csrdrif"]:
             # Drift that includes effects from coherent synchrotron radiation
@@ -94,9 +86,7 @@ def convert_element(
                 ["element_type", "l", "group", "use_stupakov", "n_kicks", "csr"], parsed
             )
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
         elif parsed["element_type"] in ["lscdrift", "lscdrif"]:
             # Drift that includes space charge effects
@@ -115,9 +105,7 @@ def convert_element(
                 parsed,
             )
             return cheetah.Drift(
-                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
-                name=name,
-                **factory_kwargs,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
         elif parsed["element_type"] == "ecol":
             validate_understood_properties(
@@ -129,7 +117,6 @@ def convert_element(
                     cheetah.Drift(
                         length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                         name=name + "_drift",
-                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
@@ -140,7 +127,6 @@ def convert_element(
                         ),
                         shape="elliptical",
                         name=name + "_aperture",
-                        **factory_kwargs,
                     ),
                 ],
                 name=name + "_segment",
@@ -155,7 +141,6 @@ def convert_element(
                     cheetah.Drift(
                         length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                         name=name + "_drift",
-                        **factory_kwargs,
                     ),
                     cheetah.Aperture(
                         x_max=torch.tensor(
@@ -166,7 +151,6 @@ def convert_element(
                         ),
                         shape="rectangular",
                         name=name + "_aperture",
-                        **factory_kwargs,
                     ),
                 ],
                 name=name + "_segment",
@@ -181,7 +165,6 @@ def convert_element(
                 k1=torch.tensor(parsed["k1"], **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "moni":
             validate_understood_properties(["element_type", "group", "l"], parsed)
@@ -191,13 +174,11 @@ def convert_element(
                         cheetah.Drift(
                             length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
                             name=name + "_predrift",
-                            **factory_kwargs,
                         ),
                         cheetah.BPM(name=name),
                         cheetah.Drift(
                             length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
                             name=name + "_postdrift",
-                            **factory_kwargs,
                         ),
                     ],
                     name=name + "_segment",
@@ -233,7 +214,6 @@ def convert_element(
                 length=torch.tensor(parsed["l"], **factory_kwargs),
                 predefined_transfer_map=R,
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfca":
             validate_understood_properties(
@@ -261,7 +241,6 @@ def convert_element(
                 voltage=torch.tensor(parsed["volt"], **factory_kwargs),
                 frequency=torch.tensor(parsed["freq"], **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfcw":
             validate_understood_properties(
@@ -304,7 +283,6 @@ def convert_element(
                 voltage=torch.tensor(parsed["volt"], **factory_kwargs),
                 frequency=torch.tensor(parsed["freq"], **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "rfdf":
             validate_understood_properties(
@@ -328,7 +306,6 @@ def convert_element(
                 voltage=torch.tensor(parsed["voltage"], **factory_kwargs),
                 frequency=torch.tensor(parsed["frequency"], **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] in ["sben", "csbend"]:
             validate_understood_properties(
@@ -343,7 +320,6 @@ def convert_element(
                 dipole_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "rben":
             validate_understood_properties(
@@ -357,7 +333,6 @@ def convert_element(
                 rbend_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "csrcsben":
             validate_understood_properties(
@@ -392,7 +367,6 @@ def convert_element(
                 dipole_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
-                **factory_kwargs,
             )
         elif parsed["element_type"] == "watch":
             validate_understood_properties(
@@ -413,9 +387,7 @@ def convert_element(
             )
             # TODO: Remove the length if by adding markers to Cheetah
             return cheetah.Drift(
-                name=name,
-                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
-                **factory_kwargs,
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
     else:
         raise ValueError(

--- a/cheetah/converters/ocelot.py
+++ b/cheetah/converters/ocelot.py
@@ -35,90 +35,90 @@ def convert_element_to_cheetah(
         )
 
     factory_kwargs = {
-        "device": device,
-        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+        "device": device or torch.get_default_device(),
+        "dtype": dtype or torch.get_default_dtype(),
     }
 
     if isinstance(element, ocelot.Drift):
         return cheetah.Drift(
-            length=torch.tensor(element.l, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Quadrupole):
         return cheetah.Quadrupole(
-            length=torch.tensor(element.l, **factory_kwargs),
-            k1=torch.tensor(element.k1, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            k1=torch.as_tensor(element.k1, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Solenoid):
         return cheetah.Solenoid(
-            length=torch.tensor(element.l, **factory_kwargs),
-            k=torch.tensor(element.k, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            k=torch.as_tensor(element.k, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Hcor):
         return cheetah.HorizontalCorrector(
-            length=torch.tensor(element.l, **factory_kwargs),
-            angle=torch.tensor(element.angle, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            angle=torch.as_tensor(element.angle, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Vcor):
         return cheetah.VerticalCorrector(
-            length=torch.tensor(element.l, **factory_kwargs),
-            angle=torch.tensor(element.angle, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            angle=torch.as_tensor(element.angle, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Bend):
         return cheetah.Dipole(
-            length=torch.tensor(element.l, **factory_kwargs),
-            angle=torch.tensor(element.angle, **factory_kwargs),
-            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
-            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
-            tilt=torch.tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
-            gap=torch.tensor(element.gap, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            angle=torch.as_tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.as_tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.as_tensor(element.e2, **factory_kwargs),
+            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
+            gap=torch.as_tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.SBend):
         return cheetah.Dipole(
-            length=torch.tensor(element.l, **factory_kwargs),
-            angle=torch.tensor(element.angle, **factory_kwargs),
-            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
-            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
-            tilt=torch.tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
-            gap=torch.tensor(element.gap, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            angle=torch.as_tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.as_tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.as_tensor(element.e2, **factory_kwargs),
+            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
+            gap=torch.as_tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.RBend):
         return cheetah.RBend(
-            length=torch.tensor(element.l, **factory_kwargs),
-            angle=torch.tensor(element.angle, **factory_kwargs),
-            rbend_e1=torch.tensor(element.e1, **factory_kwargs) - element.angle / 2,
-            rbend_e2=torch.tensor(element.e2, **factory_kwargs) - element.angle / 2,
-            tilt=torch.tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
-            gap=torch.tensor(element.gap, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            angle=torch.as_tensor(element.angle, **factory_kwargs),
+            rbend_e1=torch.as_tensor(element.e1, **factory_kwargs) - element.angle / 2,
+            rbend_e2=torch.as_tensor(element.e2, **factory_kwargs) - element.angle / 2,
+            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
+            gap=torch.as_tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Cavity):
         return cheetah.Cavity(
-            length=torch.tensor(element.l, **factory_kwargs),
-            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
-            frequency=torch.tensor(element.freq, **factory_kwargs),
-            phase=torch.tensor(element.phi, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            voltage=torch.as_tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.as_tensor(element.freq, **factory_kwargs),
+            phase=torch.as_tensor(element.phi, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.TDCavity):
         # TODO: Better replacement at some point?
         return cheetah.Cavity(
-            length=torch.tensor(element.l, **factory_kwargs),
-            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
-            frequency=torch.tensor(element.freq, **factory_kwargs),
-            phase=torch.tensor(element.phi, **factory_kwargs),
+            length=torch.as_tensor(element.l, **factory_kwargs),
+            voltage=torch.as_tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.as_tensor(element.freq, **factory_kwargs),
+            phase=torch.as_tensor(element.phi, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Monitor) and ("BSC" in element.id):
@@ -131,7 +131,7 @@ def convert_element_to_cheetah(
             )
         return cheetah.Screen(
             resolution=(2448, 2040),
-            pixel_size=torch.tensor([3.5488e-6, 2.5003e-6], **factory_kwargs),
+            pixel_size=torch.as_tensor([3.5488e-6, 2.5003e-6], **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Monitor) and "BPM" in element.id:
@@ -142,13 +142,13 @@ def convert_element_to_cheetah(
         return cheetah.Marker(name=element.id)
     elif isinstance(element, ocelot.Undulator):
         return cheetah.Undulator(
-            torch.tensor(element.l, **factory_kwargs), name=element.id
+            torch.as_tensor(element.l, **factory_kwargs), name=element.id
         )
     elif isinstance(element, ocelot.Aperture):
         shape_translation = {"rect": "rectangular", "elip": "elliptical"}
         return cheetah.Aperture(
-            x_max=torch.tensor(element.xmax, **factory_kwargs),
-            y_max=torch.tensor(element.ymax, **factory_kwargs),
+            x_max=torch.as_tensor(element.xmax, **factory_kwargs),
+            y_max=torch.as_tensor(element.ymax, **factory_kwargs),
             shape=shape_translation[element.type],
             is_active=True,
             name=element.id,
@@ -160,7 +160,7 @@ def convert_element_to_cheetah(
                 " replacing with drift section."
             )
         return cheetah.Drift(
-            length=torch.tensor(element.l, **factory_kwargs), name=element.id
+            length=torch.as_tensor(element.l, **factory_kwargs), name=element.id
         )
 
 

--- a/cheetah/converters/ocelot.py
+++ b/cheetah/converters/ocelot.py
@@ -4,7 +4,7 @@ import cheetah
 
 
 def convert_element_to_cheetah(
-    element, warnings: bool = True, device=None, dtype=torch.float32
+    element, warnings: bool = True, device=None, dtype=None
 ) -> "cheetah.Element":
     """
     Translate an Ocelot element to a Cheetah element.
@@ -29,107 +29,89 @@ def convert_element_to_cheetah(
         installed, see https://github.com/ocelot-collab/ocelot """
         )
 
+    factory_kwargs = {"device": device, "dtype": dtype}
+
     if isinstance(element, ocelot.Drift):
         return cheetah.Drift(
-            length=torch.tensor(element.l, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Quadrupole):
         return cheetah.Quadrupole(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            k1=torch.tensor(element.k1, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            k1=torch.tensor(element.k1, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Solenoid):
         return cheetah.Solenoid(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            k=torch.tensor(element.k, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            k=torch.tensor(element.k, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Hcor):
         return cheetah.HorizontalCorrector(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            angle=torch.tensor(element.angle, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Vcor):
         return cheetah.VerticalCorrector(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            angle=torch.tensor(element.angle, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Bend):
         return cheetah.Dipole(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            angle=torch.tensor(element.angle, dtype=torch.float32),
-            dipole_e1=torch.tensor(element.e1, dtype=torch.float32),
-            dipole_e2=torch.tensor(element.e2, dtype=torch.float32),
-            tilt=torch.tensor(element.tilt, dtype=torch.float32),
-            fringe_integral=torch.tensor(element.fint, dtype=torch.float32),
-            fringe_integral_exit=torch.tensor(element.fintx, dtype=torch.float32),
-            gap=torch.tensor(element.gap, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.SBend):
         return cheetah.Dipole(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            angle=torch.tensor(element.angle, dtype=torch.float32),
-            dipole_e1=torch.tensor(element.e1, dtype=torch.float32),
-            dipole_e2=torch.tensor(element.e2, dtype=torch.float32),
-            tilt=torch.tensor(element.tilt, dtype=torch.float32),
-            fringe_integral=torch.tensor(element.fint, dtype=torch.float32),
-            fringe_integral_exit=torch.tensor(element.fintx, dtype=torch.float32),
-            gap=torch.tensor(element.gap, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.RBend):
         return cheetah.RBend(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            angle=torch.tensor(element.angle, dtype=torch.float32),
-            rbend_e1=torch.tensor(element.e1, dtype=torch.float32) - element.angle / 2,
-            rbend_e2=torch.tensor(element.e2, dtype=torch.float32) - element.angle / 2,
-            tilt=torch.tensor(element.tilt, dtype=torch.float32),
-            fringe_integral=torch.tensor(element.fint, dtype=torch.float32),
-            fringe_integral_exit=torch.tensor(element.fintx, dtype=torch.float32),
-            gap=torch.tensor(element.gap, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            rbend_e1=torch.tensor(element.e1, **factory_kwargs) - element.angle / 2,
+            rbend_e2=torch.tensor(element.e2, **factory_kwargs) - element.angle / 2,
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Cavity):
         return cheetah.Cavity(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            voltage=torch.tensor(element.v, dtype=torch.float32) * 1e9,
-            frequency=torch.tensor(element.freq, dtype=torch.float32),
-            phase=torch.tensor(element.phi, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.tensor(element.freq, **factory_kwargs),
+            phase=torch.tensor(element.phi, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.TDCavity):
         # TODO: Better replacement at some point?
         return cheetah.Cavity(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            voltage=torch.tensor(element.v, dtype=torch.float32) * 1e9,
-            frequency=torch.tensor(element.freq, dtype=torch.float32),
-            phase=torch.tensor(element.phi, dtype=torch.float32),
+            length=torch.tensor(element.l, **factory_kwargs),
+            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.tensor(element.freq, **factory_kwargs),
+            phase=torch.tensor(element.phi, **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Monitor) and ("BSC" in element.id):
         # NOTE This pattern is very specific to ARES and will need a more complex
@@ -141,10 +123,8 @@ def convert_element_to_cheetah(
             )
         return cheetah.Screen(
             resolution=(2448, 2040),
-            pixel_size=torch.tensor([3.5488e-6, 2.5003e-6]),
+            pixel_size=torch.tensor([3.5488e-6, 2.5003e-6], **factory_kwargs),
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     elif isinstance(element, ocelot.Monitor) and "BPM" in element.id:
         return cheetah.BPM(name=element.id)
@@ -154,21 +134,16 @@ def convert_element_to_cheetah(
         return cheetah.Marker(name=element.id)
     elif isinstance(element, ocelot.Undulator):
         return cheetah.Undulator(
-            torch.tensor(element.l, dtype=torch.float32),
-            name=element.id,
-            device=device,
-            dtype=dtype,
+            torch.tensor(element.l, **factory_kwargs), name=element.id
         )
     elif isinstance(element, ocelot.Aperture):
         shape_translation = {"rect": "rectangular", "elip": "elliptical"}
         return cheetah.Aperture(
-            x_max=torch.tensor(element.xmax, dtype=torch.float32),
-            y_max=torch.tensor(element.ymax, dtype=torch.float32),
+            x_max=torch.tensor(element.xmax, **factory_kwargs),
+            y_max=torch.tensor(element.ymax, **factory_kwargs),
             shape=shape_translation[element.type],
             is_active=True,
             name=element.id,
-            device=device,
-            dtype=dtype,
         )
     else:
         if warnings:
@@ -177,10 +152,7 @@ def convert_element_to_cheetah(
                 " replacing with drift section."
             )
         return cheetah.Drift(
-            length=torch.tensor(element.l, dtype=torch.float32),
-            name=element.id,
-            device=device,
-            dtype=dtype,
+            length=torch.tensor(element.l, **factory_kwargs), name=element.id
         )
 
 

--- a/cheetah/converters/ocelot.py
+++ b/cheetah/converters/ocelot.py
@@ -41,84 +41,84 @@ def convert_element_to_cheetah(
 
     if isinstance(element, ocelot.Drift):
         return cheetah.Drift(
-            length=torch.as_tensor(element.l, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Quadrupole):
         return cheetah.Quadrupole(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            k1=torch.as_tensor(element.k1, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            k1=torch.tensor(element.k1, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Solenoid):
         return cheetah.Solenoid(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            k=torch.as_tensor(element.k, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            k=torch.tensor(element.k, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Hcor):
         return cheetah.HorizontalCorrector(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            angle=torch.as_tensor(element.angle, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Vcor):
         return cheetah.VerticalCorrector(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            angle=torch.as_tensor(element.angle, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Bend):
         return cheetah.Dipole(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            angle=torch.as_tensor(element.angle, **factory_kwargs),
-            dipole_e1=torch.as_tensor(element.e1, **factory_kwargs),
-            dipole_e2=torch.as_tensor(element.e2, **factory_kwargs),
-            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
-            gap=torch.as_tensor(element.gap, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.SBend):
         return cheetah.Dipole(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            angle=torch.as_tensor(element.angle, **factory_kwargs),
-            dipole_e1=torch.as_tensor(element.e1, **factory_kwargs),
-            dipole_e2=torch.as_tensor(element.e2, **factory_kwargs),
-            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
-            gap=torch.as_tensor(element.gap, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            dipole_e1=torch.tensor(element.e1, **factory_kwargs),
+            dipole_e2=torch.tensor(element.e2, **factory_kwargs),
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.RBend):
         return cheetah.RBend(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            angle=torch.as_tensor(element.angle, **factory_kwargs),
-            rbend_e1=torch.as_tensor(element.e1, **factory_kwargs) - element.angle / 2,
-            rbend_e2=torch.as_tensor(element.e2, **factory_kwargs) - element.angle / 2,
-            tilt=torch.as_tensor(element.tilt, **factory_kwargs),
-            fringe_integral=torch.as_tensor(element.fint, **factory_kwargs),
-            fringe_integral_exit=torch.as_tensor(element.fintx, **factory_kwargs),
-            gap=torch.as_tensor(element.gap, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            angle=torch.tensor(element.angle, **factory_kwargs),
+            rbend_e1=torch.tensor(element.e1, **factory_kwargs) - element.angle / 2,
+            rbend_e2=torch.tensor(element.e2, **factory_kwargs) - element.angle / 2,
+            tilt=torch.tensor(element.tilt, **factory_kwargs),
+            fringe_integral=torch.tensor(element.fint, **factory_kwargs),
+            fringe_integral_exit=torch.tensor(element.fintx, **factory_kwargs),
+            gap=torch.tensor(element.gap, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Cavity):
         return cheetah.Cavity(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            voltage=torch.as_tensor(element.v, **factory_kwargs) * 1e9,
-            frequency=torch.as_tensor(element.freq, **factory_kwargs),
-            phase=torch.as_tensor(element.phi, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.tensor(element.freq, **factory_kwargs),
+            phase=torch.tensor(element.phi, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.TDCavity):
         # TODO: Better replacement at some point?
         return cheetah.Cavity(
-            length=torch.as_tensor(element.l, **factory_kwargs),
-            voltage=torch.as_tensor(element.v, **factory_kwargs) * 1e9,
-            frequency=torch.as_tensor(element.freq, **factory_kwargs),
-            phase=torch.as_tensor(element.phi, **factory_kwargs),
+            length=torch.tensor(element.l, **factory_kwargs),
+            voltage=torch.tensor(element.v, **factory_kwargs) * 1e9,
+            frequency=torch.tensor(element.freq, **factory_kwargs),
+            phase=torch.tensor(element.phi, **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Monitor) and ("BSC" in element.id):
@@ -131,7 +131,7 @@ def convert_element_to_cheetah(
             )
         return cheetah.Screen(
             resolution=(2448, 2040),
-            pixel_size=torch.as_tensor([3.5488e-6, 2.5003e-6], **factory_kwargs),
+            pixel_size=torch.tensor([3.5488e-6, 2.5003e-6], **factory_kwargs),
             name=element.id,
         )
     elif isinstance(element, ocelot.Monitor) and "BPM" in element.id:
@@ -142,13 +142,13 @@ def convert_element_to_cheetah(
         return cheetah.Marker(name=element.id)
     elif isinstance(element, ocelot.Undulator):
         return cheetah.Undulator(
-            torch.as_tensor(element.l, **factory_kwargs), name=element.id
+            torch.tensor(element.l, **factory_kwargs), name=element.id
         )
     elif isinstance(element, ocelot.Aperture):
         shape_translation = {"rect": "rectangular", "elip": "elliptical"}
         return cheetah.Aperture(
-            x_max=torch.as_tensor(element.xmax, **factory_kwargs),
-            y_max=torch.as_tensor(element.ymax, **factory_kwargs),
+            x_max=torch.tensor(element.xmax, **factory_kwargs),
+            y_max=torch.tensor(element.ymax, **factory_kwargs),
             shape=shape_translation[element.type],
             is_active=True,
             name=element.id,
@@ -160,7 +160,7 @@ def convert_element_to_cheetah(
                 " replacing with drift section."
             )
         return cheetah.Drift(
-            length=torch.as_tensor(element.l, **factory_kwargs), name=element.id
+            length=torch.tensor(element.l, **factory_kwargs), name=element.id
         )
 
 

--- a/cheetah/converters/ocelot.py
+++ b/cheetah/converters/ocelot.py
@@ -1,10 +1,15 @@
+from typing import Optional
+
 import torch
 
 import cheetah
 
 
 def convert_element_to_cheetah(
-    element, warnings: bool = True, device=None, dtype=None
+    element,
+    warnings: bool = True,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> "cheetah.Element":
     """
     Translate an Ocelot element to a Cheetah element.
@@ -29,7 +34,10 @@ def convert_element_to_cheetah(
         installed, see https://github.com/ocelot-collab/ocelot """
         )
 
-    factory_kwargs = {"device": device, "dtype": dtype}
+    factory_kwargs = {
+        "device": device,
+        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+    }
 
     if isinstance(element, ocelot.Drift):
         return cheetah.Drift(

--- a/cheetah/latticejson.py
+++ b/cheetah/latticejson.py
@@ -131,47 +131,78 @@ class CompactJSONEncoder(json.JSONEncoder):
             return json.dumps(obj)
 
 
-def nontorch2feature(value: Any) -> Any:
+def nontorch2feature(
+    value: Any,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> Any:
     """
     Convert a value like a `float`, `int`, etc. to a `torch.Tensor` if necessary.
     Values of type `str` and `bool` are not converted, because all currently existing
     `cheetah.Element` subclasses expect these values to not be of type `torch.Tensor`.
 
     :param value: Value to convert to a `torch.Tensor` if necessary.
+    :param device: Device to place the lattice elements on.
+    :param dtype: Data type to use for the lattice elements.
     :return: Value converted to a `torch.Tensor` if necessary.
     """
-    return value if isinstance(value, (str, bool)) else torch.tensor(value)
+    return (
+        value
+        if isinstance(value, (str, bool))
+        else torch.tensor(value, device=device, dtype=dtype)
+    )
 
 
-def parse_element(name: str, lattice_dict: dict) -> "cheetah.Element":
+def parse_element(
+    name: str,
+    lattice_dict: dict,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> "cheetah.Element":
     """
     Parse an `Element` named `name` from a `lattice_dict`.
 
     :param name: Name of the `Element` to parse.
     :param lattice_dict: Dictionary containing the lattice information.
+    :param device: Device to place the lattice elements on.
+    :param dtype: Data type to use for the lattice elements.
     """
     element_class = getattr(cheetah, lattice_dict["elements"][name][0])
     params = lattice_dict["elements"][name][1]
 
-    converted_params = {key: nontorch2feature(value) for key, value in params.items()}
+    converted_params = {
+        key: nontorch2feature(value, device=device, dtype=dtype)
+        for key, value in params.items()
+    }
 
     return element_class(name=name, **converted_params)
 
 
-def parse_segment(name: str, lattice_dict: dict) -> "cheetah.Segment":
+def parse_segment(
+    name: str,
+    lattice_dict: dict,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> "cheetah.Segment":
     """
     Parse a `Segment` named `name` from a `lattice_dict`.
 
     :param name: Name of the `Segment` to parse.
     :param lattice_dict: Dictionary containing the lattice information.
+    :param device: Device to place the lattice elements on.
+    :param dtype: Data type to use for the lattice elements.
     """
     elements = []
     for element_name in lattice_dict["lattices"][name]:
         # Construct new element
         if element_name in lattice_dict["lattices"]:
-            new_element = parse_segment(element_name, lattice_dict)
+            new_element = parse_segment(
+                element_name, lattice_dict, device=device, dtype=dtype
+            )
         else:
-            new_element = parse_element(element_name, lattice_dict)
+            new_element = parse_element(
+                element_name, lattice_dict, device=device, dtype=dtype
+            )
 
         # Append the element to the list of elements
         elements.append(new_element)
@@ -179,16 +210,24 @@ def parse_segment(name: str, lattice_dict: dict) -> "cheetah.Segment":
     return cheetah.Segment(elements=elements, name=name)
 
 
-def load_cheetah_model(filename: str) -> "cheetah.Segment":
+def load_cheetah_model(
+    filename: str,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> "cheetah.Segment":
     """
     Load a Cheetah model from a JSON file.
 
     :param filename: Name/path of the file to load the lattice from.
+    :param device: Device to place the lattice elements on.
+    :param dtype: Data type to use for the lattice elements.
     :return: Loaded Cheetah `Segment`.
     """
+    dtype = dtype if dtype is not None else torch.get_default_dtype()
+
     with open(filename, "r") as f:
         lattice_dict = json.load(f)
 
     root_name = lattice_dict["root"]
 
-    return parse_segment(root_name, lattice_dict)
+    return parse_segment(root_name, lattice_dict, device=device, dtype=dtype)

--- a/cheetah/latticejson.py
+++ b/cheetah/latticejson.py
@@ -148,7 +148,9 @@ def nontorch2feature(
     """
     return (
         value
-        if isinstance(value, (str, bool))
+        if isinstance(value, (str, bool, int))
+        or isinstance(value, (tuple, list))
+        and all(isinstance(v, (str, bool, int)) for v in value)
         else torch.tensor(value, device=device, dtype=dtype)
     )
 

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -137,7 +137,9 @@ class Beam(ABC, nn.Module):
 
     @classmethod
     @abstractmethod
-    def from_astra(cls, path: str, device=None, dtype=None) -> "Beam":
+    def from_astra(
+        cls, path: str, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "Beam":
         """Load an Astra particle distribution as a Cheetah Beam."""
         raise NotImplementedError
 

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -129,10 +129,10 @@ class Beam(ABC, nn.Module):
 
     @classmethod
     @abstractmethod
-    def from_ocelot(cls, parray, device=None, dtype=None) -> "Beam":
-        """
-        Convert an Ocelot ParticleArray `parray` to a Cheetah Beam.
-        """
+    def from_ocelot(
+        cls, parray, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "Beam":
+        """Convert an Ocelot ParticleArray `parray` to a Cheetah Beam."""
         raise NotImplementedError
 
     @classmethod

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -288,7 +288,9 @@ class ParameterBeam(Beam):
         )
 
     @classmethod
-    def from_ocelot(cls, parray, device=None, dtype=None) -> "ParameterBeam":
+    def from_ocelot(
+        cls, parray, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "ParameterBeam":
         """Load an Ocelot ParticleArray `parray` as a Cheetah Beam."""
         total_charge = torch.as_tensor(parray.q_array, device=device, dtype=dtype).sum()
 
@@ -305,12 +307,7 @@ class ParameterBeam(Beam):
 
         energy = torch.as_tensor(1e9 * parray.E, **factory_kwargs)
 
-        return cls(
-            mu=mu.unsqueeze(0),
-            cov=cov.unsqueeze(0),
-            energy=energy.unsqueeze(0),
-            total_charge=total_charge.unsqueeze(0),
-        )
+        return cls(mu=mu, cov=cov, energy=energy, total_charge=total_charge)
 
     @classmethod
     def from_astra(
@@ -325,7 +322,7 @@ class ParameterBeam(Beam):
         ).sum()
 
         # If no explicit values are given, device and dtype are determined from the
-        # astra input data.
+        # Astra input data.
         factory_kwargs = {"device": total_charge.device, "dtype": total_charge.dtype}
         particles = torch.as_tensor(particles, **factory_kwargs)
 

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -313,7 +313,9 @@ class ParameterBeam(Beam):
         )
 
     @classmethod
-    def from_astra(cls, path: str, device=None, dtype=torch.float32) -> "ParameterBeam":
+    def from_astra(
+        cls, path: str, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "ParameterBeam":
         """Load an Astra particle distribution as a Cheetah Beam."""
         from cheetah.converters.astra import from_astrabeam
 

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -319,26 +319,23 @@ class ParameterBeam(Beam):
         from cheetah.converters.astra import from_astrabeam
 
         particles, energy, particle_charges = from_astrabeam(path)
-        total_charge = torch.as_tensor(
-            particle_charges, device=device, dtype=dtype
-        ).sum()
+        particles = torch.as_tensor(particles)
+        energy = torch.as_tensor(energy)
+        particle_charges = torch.as_tensor(particle_charges)
 
-        # If no explicit values are given, device and dtype are determined from the
-        # Astra input data.
-        factory_kwargs = {"device": total_charge.device, "dtype": total_charge.dtype}
-        particles = torch.as_tensor(particles, **factory_kwargs)
-
-        mu = torch.ones(7, **factory_kwargs)
+        mu = torch.ones(7)
         mu[:6] = particles.mean(dim=0)
 
-        cov = torch.zeros(7, 7, **factory_kwargs)
+        cov = torch.zeros(7, 7)
         cov[:6, :6] = particles.T.cov()
 
         return cls(
             mu=mu,
             cov=cov,
-            energy=torch.as_tensor(energy, **factory_kwargs),
-            total_charge=total_charge,
+            energy=energy,
+            total_charge=particle_charges.sum(),
+            device=device or torch.get_default_device(),
+            dtype=dtype or torch.get_default_dtype(),
         )
 
     def transformed_to(

--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import numpy as np
 import torch
 
 from cheetah.particles.beam import Beam
@@ -299,7 +300,7 @@ class ParameterBeam(Beam):
 
         cov = torch.zeros(7, 7, device=device, dtype=dtype)
         cov[:6, :6] = torch.as_tensor(
-            parray.rparticles.cov(), device=device, dtype=dtype
+            np.cov(parray.rparticles), device=device, dtype=dtype
         )
 
         energy = 1e9 * torch.as_tensor(parray.E)
@@ -328,7 +329,7 @@ class ParameterBeam(Beam):
 
         cov = torch.zeros(7, 7, device=device, dtype=dtype)
         cov[:6, :6] = torch.as_tensor(
-            particles.transpose().cov(), device=device, dtype=dtype
+            np.cov(particles.transpose()), device=device, dtype=dtype
         )
 
         total_charge = torch.as_tensor(particle_charges).sum()

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -639,26 +639,19 @@ class ParticleBeam(Beam):
         cls, parray, device: torch.device = None, dtype: torch.dtype = None
     ) -> "ParticleBeam":
         """Convert an Ocelot ParticleArray `parray` to a Cheetah Beam."""
-        particle_charges = torch.as_tensor(parray.q_array, device=device, dtype=dtype)
-
-        # If no explicit values are given, device and dtype are determined from the
-        # Ocelot input data.
-        factory_kwargs = {
-            "device": particle_charges.device,
-            "dtype": particle_charges.dtype,
-        }
-
         num_particles = parray.rparticles.shape[1]
-        particles = torch.ones((num_particles, 7), **factory_kwargs)
+        particles = torch.ones((num_particles, 7), device=device, dtype=dtype)
         particles[:, :6] = torch.as_tensor(
-            parray.rparticles.transpose(), **factory_kwargs
+            parray.rparticles, device=device, dtype=dtype
         )
-        energy = torch.as_tensor(1e9 * parray.E, **factory_kwargs)
+        particle_charges = torch.as_tensor(parray.q)
 
         return cls(
-            particles=particles.unsqueeze(0),
-            energy=energy.unsqueeze(0),
-            particle_charges=particle_charges.unsqueeze(0),
+            particles=particles,
+            energy=1e9 * torch.as_tensor(parray.E),
+            particle_charges=particle_charges,
+            device=device or torch.get_default_device(),
+            dtype=dtype or torch.get_default_dtype(),
         )
 
     @classmethod

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -659,7 +659,6 @@ class ParticleBeam(Beam):
             particles=particles.unsqueeze(0),
             energy=energy.unsqueeze(0),
             particle_charges=particle_charges.unsqueeze(0),
-            **factory_kwargs,
         )
 
     @classmethod
@@ -684,7 +683,6 @@ class ParticleBeam(Beam):
             particles=particles_7d,
             energy=torch.as_tensor(energy, **factory_kwargs),
             particle_charges=particle_charges,
-            **factory_kwargs,
         )
 
     @classmethod

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -644,7 +644,7 @@ class ParticleBeam(Beam):
         particles[:, :6] = torch.as_tensor(
             parray.rparticles, device=device, dtype=dtype
         )
-        particle_charges = torch.as_tensor(parray.q)
+        particle_charges = torch.as_tensor(parray.q_array)
 
         return cls(
             particles=particles,

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -642,7 +642,7 @@ class ParticleBeam(Beam):
         num_particles = parray.rparticles.shape[1]
         particles = torch.ones((num_particles, 7), device=device, dtype=dtype)
         particles[:, :6] = torch.as_tensor(
-            parray.rparticles, device=device, dtype=dtype
+            parray.rparticles.transpose(), device=device, dtype=dtype
         )
         particle_charges = torch.as_tensor(parray.q_array)
 

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -635,10 +635,10 @@ class ParticleBeam(Beam):
         )
 
     @classmethod
-    def from_ocelot(cls, parray, device=None, dtype=None) -> "ParticleBeam":
-        """
-        Convert an Ocelot ParticleArray `parray` to a Cheetah Beam.
-        """
+    def from_ocelot(
+        cls, parray, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "ParticleBeam":
+        """Convert an Ocelot ParticleArray `parray` to a Cheetah Beam."""
         particle_charges = torch.as_tensor(parray.q_array, device=device, dtype=dtype)
 
         # If no explicit values are given, device and dtype are determined from the

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -662,22 +662,16 @@ class ParticleBeam(Beam):
         from cheetah.converters.astra import from_astrabeam
 
         particles, energy, particle_charges = from_astrabeam(path)
-        particle_charges = torch.as_tensor(particle_charges, device=device, dtype=dtype)
 
-        # If no explicit values are given, device and dtype are determined from the
-        # astra input data.
-        factory_kwargs = {
-            "device": particle_charges.device,
-            "dtype": particle_charges.dtype,
-        }
-
-        particles_7d = torch.ones((particles.shape[0], 7), **factory_kwargs)
-        particles_7d[:, :6] = torch.as_tensor(particles, **factory_kwargs)
+        particles_7d = torch.ones((particles.shape[0], 7), device=device, dtype=dtype)
+        particles_7d[:, :6] = torch.as_tensor(particles, device=device, dtype=dtype)
 
         return cls(
             particles=particles_7d,
-            energy=torch.as_tensor(energy, **factory_kwargs),
-            particle_charges=particle_charges,
+            energy=torch.as_tensor(energy),
+            particle_charges=torch.as_tensor(particle_charges),
+            device=device or torch.get_default_device(),
+            dtype=dtype or torch.get_default_dtype(),
         )
 
     @classmethod

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -662,7 +662,9 @@ class ParticleBeam(Beam):
         )
 
     @classmethod
-    def from_astra(cls, path: str, device=None, dtype=torch.float32) -> "ParticleBeam":
+    def from_astra(
+        cls, path: str, device: torch.device = None, dtype: torch.dtype = None
+    ) -> "ParticleBeam":
         """Load an Astra particle distribution as a Cheetah Beam."""
         from cheetah.converters.astra import from_astrabeam
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,15 +37,16 @@ def seed_random_generators(request):
 
 
 @pytest.fixture
-def default_dtype(request):
+def default_torch_dtype(request):
     """Test fixture for parametrizing the default torch dtype."""
-    stored_dtype = torch.get_default_dtype()
+    tmp_dtype_for_test = request.param
+    previous_dtype = torch.get_default_dtype()
 
     # Set desired default dtype
-    torch.set_default_dtype(request.param)
+    torch.set_default_dtype(tmp_dtype_for_test)
 
     # Execute test
-    yield
+    yield tmp_dtype_for_test
 
     # Restore original default dtype
-    torch.set_default_dtype(stored_dtype)
+    torch.set_default_dtype(previous_dtype)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,18 @@ def seed_random_generators(request):
         torch.cuda.manual_seed_all(seed)
     if is_mps_available_and_functional():
         torch.mps.manual_seed(seed)
+
+
+@pytest.fixture
+def default_dtype(request):
+    """Test fixture for parametrizing the default torch dtype."""
+    stored_dtype = torch.get_default_dtype()
+
+    # Set desired default dtype
+    torch.set_default_dtype(request.param)
+
+    # Execute test
+    yield
+
+    # Restore original default dtype
+    torch.set_default_dtype(stored_dtype)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,15 +38,13 @@ def seed_random_generators(request):
 
 @pytest.fixture
 def default_torch_dtype(request):
-    """Test fixture for parametrizing the default torch dtype."""
+    """Temporarily set the default torch dtype for the test to a requested value."""
     tmp_dtype_for_test = request.param
     previous_dtype = torch.get_default_dtype()
 
-    # Set desired default dtype
     torch.set_default_dtype(tmp_dtype_for_test)
 
-    # Execute test
+    # Return the requested dtype for the test and let the test run
     yield tmp_dtype_for_test
 
-    # Restore original default dtype
     torch.set_default_dtype(previous_dtype)

--- a/tests/test_astra_import.py
+++ b/tests/test_astra_import.py
@@ -45,28 +45,29 @@ def test_astra_to_particle_beam():
 
 
 @pytest.mark.parametrize("BeamClass", [cheetah.ParameterBeam, cheetah.ParticleBeam])
-@pytest.mark.parametrize("target_dtype", [None, torch.float32, torch.float64])
-def test_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
+@pytest.mark.parametrize("desired_dtype", [None, torch.float32, torch.float64])
+def test_dtypes(BeamClass: cheetah.Beam, desired_dtype: torch.dtype):
     """
     Test that Astra beams are correctly loaded into different types of Cheetah beams
     with different dtypes.
     """
-    # If no target_dtype is specified, the default dtype of PyTorch should be used
-    target_dtype = target_dtype or torch.get_default_dtype()
-
     beam = BeamClass.from_astra(
-        "tests/resources/ACHIP_EA1_2021.1351.001", dtype=target_dtype
+        "tests/resources/ACHIP_EA1_2021.1351.001", dtype=desired_dtype
     )
 
-    assert beam.mu_x.dtype == target_dtype
-    assert beam.mu_px.dtype == target_dtype
-    assert beam.mu_y.dtype == target_dtype
-    assert beam.mu_py.dtype == target_dtype
-    assert beam.sigma_x.dtype == target_dtype
-    assert beam.sigma_px.dtype == target_dtype
-    assert beam.sigma_y.dtype == target_dtype
-    assert beam.sigma_py.dtype == target_dtype
-    assert beam.sigma_tau.dtype == target_dtype
-    assert beam.sigma_p.dtype == target_dtype
-    assert beam.energy.dtype == target_dtype
-    assert beam.total_charge.dtype == target_dtype
+    correct_dtype = (
+        desired_dtype if desired_dtype is not None else torch.get_default_dtype()
+    )
+
+    assert beam.mu_x.dtype == correct_dtype
+    assert beam.mu_px.dtype == correct_dtype
+    assert beam.mu_y.dtype == correct_dtype
+    assert beam.mu_py.dtype == correct_dtype
+    assert beam.sigma_x.dtype == correct_dtype
+    assert beam.sigma_px.dtype == correct_dtype
+    assert beam.sigma_y.dtype == correct_dtype
+    assert beam.sigma_py.dtype == correct_dtype
+    assert beam.sigma_tau.dtype == correct_dtype
+    assert beam.sigma_p.dtype == correct_dtype
+    assert beam.energy.dtype == correct_dtype
+    assert beam.total_charge.dtype == correct_dtype

--- a/tests/test_astra_import.py
+++ b/tests/test_astra_import.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 import cheetah
@@ -43,19 +44,27 @@ def test_astra_to_particle_beam():
     assert np.allclose(beam.total_charge.cpu().numpy(), 5.000000000010205e-13)
 
 
-def test_astra_to_parameter_beam_dtypes():
-    """Test that Astra beams are correctly loaded into particle beams."""
-    beam = cheetah.ParameterBeam.from_astra("tests/resources/ACHIP_EA1_2021.1351.001")
+@pytest.mark.parametrize("BeamClass", [cheetah.ParameterBeam, cheetah.ParticleBeam])
+@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64, None])
+def test_astra_to_beam_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
+    """Test that Astra beams are correctly loaded into cheetah beams."""
+    beam = BeamClass.from_astra(
+        "tests/resources/ACHIP_EA1_2021.1351.001", dtype=target_dtype
+    )
 
-    assert beam.mu_x.dtype == torch.float32
-    assert beam.mu_px.dtype == torch.float32
-    assert beam.mu_y.dtype == torch.float32
-    assert beam.mu_py.dtype == torch.float32
-    assert beam.sigma_x.dtype == torch.float32
-    assert beam.sigma_px.dtype == torch.float32
-    assert beam.sigma_y.dtype == torch.float32
-    assert beam.sigma_py.dtype == torch.float32
-    assert beam.sigma_tau.dtype == torch.float32
-    assert beam.sigma_p.dtype == torch.float32
-    assert beam.energy.dtype == torch.float32
-    assert beam.total_charge.dtype == torch.float32
+    # The imported numpy data has dtype float64, therefore that should be the default
+    if target_dtype is None:
+        target_dtype = torch.float64
+
+    assert beam.mu_x.dtype == target_dtype
+    assert beam.mu_px.dtype == target_dtype
+    assert beam.mu_y.dtype == target_dtype
+    assert beam.mu_py.dtype == target_dtype
+    assert beam.sigma_x.dtype == target_dtype
+    assert beam.sigma_px.dtype == target_dtype
+    assert beam.sigma_y.dtype == target_dtype
+    assert beam.sigma_py.dtype == target_dtype
+    assert beam.sigma_tau.dtype == target_dtype
+    assert beam.sigma_p.dtype == target_dtype
+    assert beam.energy.dtype == target_dtype
+    assert beam.total_charge.dtype == target_dtype

--- a/tests/test_astra_import.py
+++ b/tests/test_astra_import.py
@@ -55,9 +55,7 @@ def test_dtypes(BeamClass: cheetah.Beam, desired_dtype: torch.dtype):
         "tests/resources/ACHIP_EA1_2021.1351.001", dtype=desired_dtype
     )
 
-    correct_dtype = (
-        desired_dtype if desired_dtype is not None else torch.get_default_dtype()
-    )
+    correct_dtype = desired_dtype or torch.get_default_dtype()
 
     assert beam.mu_x.dtype == correct_dtype
     assert beam.mu_px.dtype == correct_dtype

--- a/tests/test_astra_import.py
+++ b/tests/test_astra_import.py
@@ -45,16 +45,18 @@ def test_astra_to_particle_beam():
 
 
 @pytest.mark.parametrize("BeamClass", [cheetah.ParameterBeam, cheetah.ParticleBeam])
-@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64, None])
-def test_astra_to_beam_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
-    """Test that Astra beams are correctly loaded into cheetah beams."""
+@pytest.mark.parametrize("target_dtype", [None, torch.float32, torch.float64])
+def test_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
+    """
+    Test that Astra beams are correctly loaded into different types of Cheetah beams
+    with different dtypes.
+    """
+    # If no target_dtype is specified, the default dtype of PyTorch should be used
+    target_dtype = target_dtype or torch.get_default_dtype()
+
     beam = BeamClass.from_astra(
         "tests/resources/ACHIP_EA1_2021.1351.001", dtype=target_dtype
     )
-
-    # The imported numpy data has dtype float64, therefore that should be the default
-    if target_dtype is None:
-        target_dtype = torch.float64
 
     assert beam.mu_x.dtype == target_dtype
     assert beam.mu_px.dtype == target_dtype

--- a/tests/test_bmad_conversion.py
+++ b/tests/test_bmad_conversion.py
@@ -85,14 +85,19 @@ def test_dtype_passing(dtype: torch.dtype):
     assert converted.q.k1.dtype == dtype
 
 
-@pytest.mark.parametrize("default_dtype", [torch.float32, torch.float64], indirect=True)
-def test_default_dtype(default_dtype):
+@pytest.mark.parametrize(
+    "default_torch_dtype", [torch.float32, torch.float64], indirect=True
+)
+def test_default_dtype(default_torch_dtype):
     """Test that the default dtype is used if no explicit type is passed."""
-    dtype = torch.get_default_dtype()
     file_path = "tests/resources/bmad_tutorial_lattice.bmad"
 
     # Convert the lattice while passing the dtype
-    converted = cheetah.Segment.from_bmad(file_path, dtype=dtype)
+    converted = cheetah.Segment.from_bmad(file_path)
 
     # Check that the properties of the loaded elements are of the correct dtype
-    assert converted.d.length.dtype == dtype
+    assert converted.d.length.dtype == default_torch_dtype
+    assert converted.b.length.dtype == default_torch_dtype
+    assert converted.b.dipole_e1.dtype == default_torch_dtype
+    assert converted.q.length.dtype == default_torch_dtype
+    assert converted.q.k1.dtype == default_torch_dtype

--- a/tests/test_bmad_conversion.py
+++ b/tests/test_bmad_conversion.py
@@ -83,3 +83,16 @@ def test_dtype_passing(dtype: torch.dtype):
     assert converted.b.dipole_e1.dtype == dtype
     assert converted.q.length.dtype == dtype
     assert converted.q.k1.dtype == dtype
+
+
+@pytest.mark.parametrize("default_dtype", [torch.float32, torch.float64], indirect=True)
+def test_default_dtype(default_dtype):
+    """Test that the default dtype is used if no explicit type is passed."""
+    dtype = torch.get_default_dtype()
+    file_path = "tests/resources/bmad_tutorial_lattice.bmad"
+
+    # Convert the lattice while passing the dtype
+    converted = cheetah.Segment.from_bmad(file_path, dtype=dtype)
+
+    # Check that the properties of the loaded elements are of the correct dtype
+    assert converted.d.length.dtype == dtype

--- a/tests/test_compare_ocelot.py
+++ b/tests/test_compare_ocelot.py
@@ -709,11 +709,11 @@ def test_cavity():
         outgoing_beam.total_charge.cpu().numpy(), np.sum(outgoing_parray.q_array)
     )
     assert np.allclose(
-        outgoing_beam.particles[:, :, 5].cpu().numpy(),
+        outgoing_beam.particles[:, 5].cpu().numpy(),
         outgoing_parray.rparticles.transpose()[:, 5],
     )
     assert np.allclose(
-        outgoing_beam.particles[:, :, 4].cpu().numpy(),
+        outgoing_beam.particles[:, 4].cpu().numpy(),
         outgoing_parray.rparticles.transpose()[:, 4],
     )
 
@@ -763,10 +763,10 @@ def test_cavity_non_zero_phase():
         outgoing_beam.total_charge.cpu().numpy(), np.sum(outgoing_parray.q_array)
     )
     assert np.allclose(
-        outgoing_beam.particles[:, :, 5].cpu().numpy(),
+        outgoing_beam.particles[:, 5].cpu().numpy(),
         outgoing_parray.rparticles.transpose()[:, 5],
     )
     assert np.allclose(
-        outgoing_beam.particles[:, :, 4].cpu().numpy(),
+        outgoing_beam.particles[:, 4].cpu().numpy(),
         outgoing_parray.rparticles.transpose()[:, 4],
     )

--- a/tests/test_elegant_conversion.py
+++ b/tests/test_elegant_conversion.py
@@ -134,14 +134,22 @@ def test_dtype_passing(dtype: torch.dtype):
     assert converted.s1.dipole_e1.dtype == dtype
 
 
-@pytest.mark.parametrize("default_dtype", [torch.float32, torch.float64], indirect=True)
-def test_default_dtype(default_dtype):
+@pytest.mark.parametrize(
+    "default_torch_dtype", [torch.float32, torch.float64], indirect=True
+)
+def test_default_dtype(default_torch_dtype):
     """Test that the default dtype is used if no explicit type is passed."""
-    dtype = torch.get_default_dtype()
     file_path = "tests/resources/fodo.lte"
 
     # Convert the lattice while passing the device
     converted = cheetah.Segment.from_elegant(file_path, "fodo")
 
     # Check that the properties of the loaded elements are of the correct dtype
-    assert converted.q1.length.dtype == dtype
+    assert converted.q1.length.dtype == default_torch_dtype
+    assert converted.q1.k1.dtype == default_torch_dtype
+    assert converted.q2.length.dtype == default_torch_dtype
+    assert converted.q2.k1.dtype == default_torch_dtype
+    assert [d.length.dtype for d in converted.d1] == [default_torch_dtype] * 2
+    assert converted.d2.length.dtype == default_torch_dtype
+    assert converted.s1.length.dtype == default_torch_dtype
+    assert converted.s1.dipole_e1.dtype == default_torch_dtype

--- a/tests/test_elegant_conversion.py
+++ b/tests/test_elegant_conversion.py
@@ -132,3 +132,16 @@ def test_dtype_passing(dtype: torch.dtype):
     assert converted.d2.length.dtype == dtype
     assert converted.s1.length.dtype == dtype
     assert converted.s1.dipole_e1.dtype == dtype
+
+
+@pytest.mark.parametrize("default_dtype", [torch.float32, torch.float64], indirect=True)
+def test_default_dtype(default_dtype):
+    """Test that the default dtype is used if no explicit type is passed."""
+    dtype = torch.get_default_dtype()
+    file_path = "tests/resources/fodo.lte"
+
+    # Convert the lattice while passing the device
+    converted = cheetah.Segment.from_elegant(file_path, "fodo")
+
+    # Check that the properties of the loaded elements are of the correct dtype
+    assert converted.q1.length.dtype == dtype

--- a/tests/test_lattice_json.py
+++ b/tests/test_lattice_json.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 import cheetah
@@ -68,3 +69,28 @@ def test_save_and_reload_custom_transfer_map(tmp_path):
         custom_transfer_map_element.length, reloaded_custom_transfer_map_element.length
     )
     assert custom_transfer_map_element.name == reloaded_custom_transfer_map_element.name
+
+
+@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64])
+def test_dtype(tmp_path, target_dtype: torch.dtype):
+    """
+    Test that the lattice JSON import correctly interprets its optional dtype parameter.
+    """
+    original_segment = cheetah.Segment(
+        elements=[
+            cheetah.Drift(length=torch.tensor(1.0)),
+            cheetah.Dipole(length=torch.tensor(0.5), angle=torch.tensor(1e-3)),
+            cheetah.Quadrupole(length=torch.tensor(0.3), k1=torch.tensor(31.415)),
+        ]
+    )
+    original_segment.to_lattice_json(str(tmp_path / "dummy_lattice.json"))
+
+    reloaded_segment = cheetah.Segment.from_lattice_json(
+        str(tmp_path / "dummy_lattice.json"), dtype=target_dtype
+    )
+
+    assert all(
+        buffer.dtype == target_dtype
+        for element in reloaded_segment.elements
+        for buffer in element.buffers()
+    )

--- a/tests/test_lattice_json.py
+++ b/tests/test_lattice_json.py
@@ -71,8 +71,8 @@ def test_save_and_reload_custom_transfer_map(tmp_path):
     assert custom_transfer_map_element.name == reloaded_custom_transfer_map_element.name
 
 
-@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64])
-def test_dtype(tmp_path, target_dtype: torch.dtype):
+@pytest.mark.parametrize("desired_dtype", [torch.float32, torch.float64])
+def test_desired_dtype(tmp_path, desired_dtype: torch.dtype):
     """
     Test that the lattice JSON import correctly interprets its optional dtype parameter.
     """
@@ -86,11 +86,11 @@ def test_dtype(tmp_path, target_dtype: torch.dtype):
     original_segment.to_lattice_json(str(tmp_path / "dummy_lattice.json"))
 
     reloaded_segment = cheetah.Segment.from_lattice_json(
-        str(tmp_path / "dummy_lattice.json"), dtype=target_dtype
+        str(tmp_path / "dummy_lattice.json"), dtype=desired_dtype
     )
 
     assert all(
-        buffer.dtype == target_dtype
+        buffer.dtype == desired_dtype
         for element in reloaded_segment.elements
         for buffer in element.buffers()
     )

--- a/tests/test_ocelot_import.py
+++ b/tests/test_ocelot_import.py
@@ -69,28 +69,28 @@ def test_ocelot_to_particlebeam():
 
 
 @pytest.mark.parametrize("BeamClass", [cheetah.ParameterBeam, cheetah.ParticleBeam])
-@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64, None])
-def test_ocelot_to_beam_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
-    """Test that Ocelot beams are correctly loaded into cheetah beams."""
+@pytest.mark.parametrize("desired_dtype", [None, torch.float32, torch.float64])
+def test_beam_desired_dtype(BeamClass: cheetah.Beam, desired_dtype: torch.dtype):
+    """Test that Ocelot import respects the desired dtype."""
     parray = ocelot.astraBeam2particleArray("tests/resources/ACHIP_EA1_2021.1351.001")
-    beam = BeamClass.from_ocelot(parray, dtype=target_dtype)
+    beam = BeamClass.from_ocelot(parray, dtype=desired_dtype)
 
-    # The imported numpy data has dtype float64, therefore that should be the default
-    if target_dtype is None:
-        target_dtype = torch.float64
+    correct_dtype = (
+        desired_dtype if desired_dtype is not None else torch.get_default_dtype()
+    )
 
-    assert beam.mu_x.dtype == target_dtype
-    assert beam.mu_px.dtype == target_dtype
-    assert beam.mu_y.dtype == target_dtype
-    assert beam.mu_py.dtype == target_dtype
-    assert beam.sigma_x.dtype == target_dtype
-    assert beam.sigma_px.dtype == target_dtype
-    assert beam.sigma_y.dtype == target_dtype
-    assert beam.sigma_py.dtype == target_dtype
-    assert beam.sigma_tau.dtype == target_dtype
-    assert beam.sigma_p.dtype == target_dtype
-    assert beam.energy.dtype == target_dtype
-    assert beam.total_charge.dtype == target_dtype
+    assert beam.mu_x.dtype == correct_dtype
+    assert beam.mu_px.dtype == correct_dtype
+    assert beam.mu_y.dtype == correct_dtype
+    assert beam.mu_py.dtype == correct_dtype
+    assert beam.sigma_x.dtype == correct_dtype
+    assert beam.sigma_px.dtype == correct_dtype
+    assert beam.sigma_y.dtype == correct_dtype
+    assert beam.sigma_py.dtype == correct_dtype
+    assert beam.sigma_tau.dtype == correct_dtype
+    assert beam.sigma_p.dtype == correct_dtype
+    assert beam.energy.dtype == correct_dtype
+    assert beam.total_charge.dtype == correct_dtype
 
 
 def test_ocelot_lattice_import():

--- a/tests/test_ocelot_import.py
+++ b/tests/test_ocelot_import.py
@@ -1,6 +1,7 @@
 import numpy as np
 import ocelot
 import pytest
+import torch
 
 import cheetah
 
@@ -65,6 +66,31 @@ def test_ocelot_to_particlebeam():
     assert np.allclose(beam.particles[0, :, 5].cpu().numpy(), parray.p())
     assert np.allclose(beam.energy.cpu().numpy(), parray.E * 1e9)
     assert np.allclose(beam.particle_charges.cpu().numpy(), parray.q_array)
+
+
+@pytest.mark.parametrize("BeamClass", [cheetah.ParameterBeam, cheetah.ParticleBeam])
+@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64, None])
+def test_ocelot_to_beam_dtypes(BeamClass: cheetah.Beam, target_dtype: torch.dtype):
+    """Test that Ocelot beams are correctly loaded into cheetah beams."""
+    parray = ocelot.astraBeam2particleArray("tests/resources/ACHIP_EA1_2021.1351.001")
+    beam = BeamClass.from_ocelot(parray, dtype=target_dtype)
+
+    # The imported numpy data has dtype float64, therefore that should be the default
+    if target_dtype is None:
+        target_dtype = torch.float64
+
+    assert beam.mu_x.dtype == target_dtype
+    assert beam.mu_px.dtype == target_dtype
+    assert beam.mu_y.dtype == target_dtype
+    assert beam.mu_py.dtype == target_dtype
+    assert beam.sigma_x.dtype == target_dtype
+    assert beam.sigma_px.dtype == target_dtype
+    assert beam.sigma_y.dtype == target_dtype
+    assert beam.sigma_py.dtype == target_dtype
+    assert beam.sigma_tau.dtype == target_dtype
+    assert beam.sigma_p.dtype == target_dtype
+    assert beam.energy.dtype == target_dtype
+    assert beam.total_charge.dtype == target_dtype
 
 
 def test_ocelot_lattice_import():

--- a/tests/test_ocelot_import.py
+++ b/tests/test_ocelot_import.py
@@ -75,9 +75,7 @@ def test_beam_desired_dtype(BeamClass: cheetah.Beam, desired_dtype: torch.dtype)
     parray = ocelot.astraBeam2particleArray("tests/resources/ACHIP_EA1_2021.1351.001")
     beam = BeamClass.from_ocelot(parray, dtype=desired_dtype)
 
-    correct_dtype = (
-        desired_dtype if desired_dtype is not None else torch.get_default_dtype()
-    )
+    correct_dtype = desired_dtype or torch.get_default_dtype()
 
     assert beam.mu_x.dtype == correct_dtype
     assert beam.mu_px.dtype == correct_dtype

--- a/tests/test_ocelot_import.py
+++ b/tests/test_ocelot_import.py
@@ -58,12 +58,12 @@ def test_ocelot_to_particlebeam():
     parray = ocelot.astraBeam2particleArray("tests/resources/ACHIP_EA1_2021.1351.001")
     beam = cheetah.ParticleBeam.from_ocelot(parray)
 
-    assert np.allclose(beam.particles[0, :, 0].cpu().numpy(), parray.x())
-    assert np.allclose(beam.particles[0, :, 1].cpu().numpy(), parray.px())
-    assert np.allclose(beam.particles[0, :, 2].cpu().numpy(), parray.y())
-    assert np.allclose(beam.particles[0, :, 3].cpu().numpy(), parray.py())
-    assert np.allclose(beam.particles[0, :, 4].cpu().numpy(), parray.tau())
-    assert np.allclose(beam.particles[0, :, 5].cpu().numpy(), parray.p())
+    assert np.allclose(beam.particles[:, 0].cpu().numpy(), parray.x())
+    assert np.allclose(beam.particles[:, 1].cpu().numpy(), parray.px())
+    assert np.allclose(beam.particles[:, 2].cpu().numpy(), parray.y())
+    assert np.allclose(beam.particles[:, 3].cpu().numpy(), parray.py())
+    assert np.allclose(beam.particles[:, 4].cpu().numpy(), parray.tau())
+    assert np.allclose(beam.particles[:, 5].cpu().numpy(), parray.p())
     assert np.allclose(beam.energy.cpu().numpy(), parray.E * 1e9)
     assert np.allclose(beam.particle_charges.cpu().numpy(), parray.q_array)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #333 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
