### PR TITLE
Make `Segment.subcell` method more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add Python 3.13 support (see #275) (@jank324)
 - Methods `to_parameter_beam` and `to_particle_beam` have been added for convenient conversion between `ParticleBeam` and `ParameterBeam` (see #331) (@jank324)
 - Beam classes now have the `mu_tau` and `mu_p` properties on their interfaces (see #331) (@jank324)
+- Add options to include or exclude the first and last element when retreiving a `Segment.subcell` and improve error handling (see #350) (@Hespe, @jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -47,7 +47,8 @@ class Segment(Element):
         self,
         start: Optional[str] = None,
         end: Optional[str] = None,
-        endpoint: bool = True,
+        include_start: bool = True,
+        include_end: bool = True,
     ) -> "Segment":
         """
         Extract a subcell from this segment.
@@ -60,19 +61,34 @@ class Segment(Element):
             passed, the subcell starts at the same element as the original segment.
         :param end: Name of the element at the end of the subcell. If `None` is
             passed, the subcell ends at the same element as the original segment.
-        :param endpoint: If True, `end` is included in the subcell, otherwise not.
+        :param include_start: If `True`, `start` is included in the subcell, otherwise
+            not.
+        :param include_end: If `True`, `end` is included in the subcell, otherwise not.
         :return: Subcell of elements from `start` to `end`.
         """
+        is_start_in_segment = start is None or start in self.__dict__
+        if not is_start_in_segment:
+            raise ValueError(f"Element {start} is not part of the segment.")
+        is_end_in_segment = end is None or end in self.__dict__
+        if not is_end_in_segment:
+            raise ValueError(f"Element {end} is not part of the segment.")
+
         subcell = []
         is_in_subcell = start is None
         for element in self.elements:
             if element.name == start:
                 is_in_subcell = True
-            if is_in_subcell:
-                if endpoint or element.name != end:
+                if include_start:
                     subcell.append(element)
+                continue
+
             if element.name == end:
+                if include_end and is_in_subcell:
+                    subcell.append(element)
                 break
+
+            if is_in_subcell:
+                subcell.append(element)
 
         return self.__class__(subcell)
 

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -53,9 +53,9 @@ class Segment(Element):
         """
         Extract a subcell from this segment.
 
-        If `start` is not part of the original segment, an empty subcell is returned.
-        If `end` is not part of the original segment, the subcell contains all elements
-        after `start`.
+        If either `start` or `end` is `None`, the subcell starts or ends at the same
+        element as the original segment. If `start` or `end` is not part of the segment,
+        a `ValueError` is raised.
 
         :param start: Name of the element at the start of the subcell. If `None` is
             passed, the subcell starts at the same element as the original segment.

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -43,15 +43,34 @@ class Segment(Element):
             else:
                 self.__dict__[element.name] = element
 
-    def subcell(self, start: str, end: str) -> "Segment":
-        """Extract a subcell `[start, end]` from an this segment."""
+    def subcell(
+        self,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        endpoint: bool = True,
+    ) -> "Segment":
+        """
+        Extract a subcell from this segment.
+
+        If `start` is not part of the original segment, an empty subcell is returned.
+        If `end` is not part of the original segment, the subcell contains all elements
+        after `start`.
+
+        :param start: Name of the element at the start of the subcell. If `None` is
+            passed, the subcell starts at the same element as the original segment.
+        :param end: Name of the element at the end of the subcell. If `None` is
+            passed, the subcell ends at the same element as the original segment.
+        :param endpoint: If True, `end` is included in the subcell, otherwise not.
+        :return: Subcell of elements from `start` to `end`.
+        """
         subcell = []
-        is_in_subcell = False
+        is_in_subcell = start is None
         for element in self.elements:
             if element.name == start:
                 is_in_subcell = True
             if is_in_subcell:
-                subcell.append(element)
+                if endpoint or element.name != end:
+                    subcell.append(element)
             if element.name == end:
                 break
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 import cheetah
@@ -22,9 +23,12 @@ def test_subcell_start_end():
     assert len(segment.subcell(start="drift_3", end="drift_4").elements) == 2
 
     # Test with invalid start or end element
-    assert len(segment.subcell(start="drift_42").elements) == 0
-    assert len(segment.subcell(end="drift_42").elements) == 10
-    assert len(segment.subcell(start="drift_5", end="drift_42").elements) == 5
+    with pytest.raises(ValueError):
+        segment.subcell(start="drift_42")
+    with pytest.raises(ValueError):
+        segment.subcell(end="drift_42")
+    with pytest.raises(ValueError):
+        segment.subcell(start="drift_3", end="drift_42")
     assert len(segment.subcell(start="drift_3", end="drift_2").elements) == 0
 
 
@@ -39,10 +43,10 @@ def test_subcell_endpoint():
 
     # Test with fixed end
     assert len(segment.subcell("drift_2", "drift_7").elements) == 6
-    assert len(segment.subcell("drift_2", "drift_7", endpoint=True).elements) == 6
-    assert len(segment.subcell("drift_2", "drift_7", endpoint=False).elements) == 5
+    assert len(segment.subcell("drift_2", "drift_7", include_end=True).elements) == 6
+    assert len(segment.subcell("drift_2", "drift_7", include_end=False).elements) == 5
 
     # Test with open end
     assert len(segment.subcell("drift_2").elements) == 8
-    assert len(segment.subcell("drift_2", endpoint=True).elements) == 8
-    assert len(segment.subcell("drift_2", endpoint=False).elements) == 8
+    assert len(segment.subcell("drift_2", include_end=True).elements) == 8
+    assert len(segment.subcell("drift_2", include_end=False).elements) == 8

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,0 +1,48 @@
+import torch
+
+import cheetah
+
+
+def test_subcell_start_end():
+    """
+    Test that `start` and `end` have proper defaults and fallbacks if the named element
+    does not exist in the original segment.
+    """
+    segment = cheetah.Segment(
+        elements=[
+            cheetah.Drift(length=torch.tensor(0.5), name=f"drift_{i}")
+            for i in range(10)
+        ]
+    )
+
+    # Test standard behaviour
+    assert len(segment.subcell().elements) == 10
+    assert len(segment.subcell(start="drift_3").elements) == 7
+    assert len(segment.subcell(end="drift_4").elements) == 5
+    assert len(segment.subcell(start="drift_3", end="drift_4").elements) == 2
+
+    # Test with invalid start or end element
+    assert len(segment.subcell(start="drift_42").elements) == 0
+    assert len(segment.subcell(end="drift_42").elements) == 10
+    assert len(segment.subcell(start="drift_5", end="drift_42").elements) == 5
+    assert len(segment.subcell(start="drift_3", end="drift_2").elements) == 0
+
+
+def test_subcell_endpoint():
+    """Test that the subcell method properly determines the new end element."""
+    segment = cheetah.Segment(
+        elements=[
+            cheetah.Drift(length=torch.tensor(0.5), name=f"drift_{i}")
+            for i in range(10)
+        ]
+    )
+
+    # Test with fixed end
+    assert len(segment.subcell("drift_2", "drift_7").elements) == 6
+    assert len(segment.subcell("drift_2", "drift_7", endpoint=True).elements) == 6
+    assert len(segment.subcell("drift_2", "drift_7", endpoint=False).elements) == 5
+
+    # Test with open end
+    assert len(segment.subcell("drift_2").elements) == 8
+    assert len(segment.subcell("drift_2", endpoint=True).elements) == 8
+    assert len(segment.subcell("drift_2", endpoint=False).elements) == 8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The current implementation of the `Segment.subcell` method does not allow for open `start` or `end` elements. Furthermore, `end` is always included in the subcell, making it cumbersome to slice a segment into multiple disjunct cells.

This PR increases the flexibility the method by making `start` and `end` optional. The additional optional `endpoint` argument allows to exclude `end` from the created subcell.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #349 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
