### PR TITLE
Fix `is_active` and `is_skippable` of some elements not being boolean properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Fix issue where a space before a comma could cause the Elegant and Bmad converters to fail (see #327) (@jank324)
 - Fix issue of `BPM` and `Screen` not properly converting the `dtype` of their readings (see #335) (@Hespe)
+- Fix `is_active` and `is_skippable` of some elements not being boolean properties (see #357) (@jank324)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Methods `to_parameter_beam` and `to_particle_beam` have been added for convenient conversion between `ParticleBeam` and `ParameterBeam` (see #331) (@jank324)
 - Beam classes now have the `mu_tau` and `mu_p` properties on their interfaces (see #331) (@jank324)
 - Lattice and beam converters now adhere to the default torch `dtype` when no explicit `dtype` is passed (see #340) (@Hespe, @jank324)
-- Add options to include or exclude the first and last element when retreiving a `Segment.subcell` and improve error handling (see #350) (@Hespe, @jank324)
+- Add options to include or exclude the first and last element when retrieving a `Segment.subcell` and improve error handling (see #350) (@Hespe, @jank324)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/__init__.py
+++ b/cheetah/__init__.py
@@ -6,6 +6,7 @@ from .accelerator import (  # noqa: F401
     CustomTransferMap,
     Dipole,
     Drift,
+    Element,
     HorizontalCorrector,
     Marker,
     Quadrupole,

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -61,7 +61,7 @@ class Cavity(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.voltage != 0)
+        return torch.any(self.voltage != 0).item()
 
     @property
     def is_skippable(self) -> bool:

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -146,8 +146,8 @@ class Dipole(Element):
         return self.tracking_method == "cheetah"
 
     @property
-    def is_active(self):
-        return torch.any(self.angle != 0)
+    def is_active(self) -> bool:
+        return torch.any(self.angle != 0).item()
 
     def track(self, incoming: Beam) -> Beam:
         """

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -67,7 +67,7 @@ class HorizontalCorrector(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.angle != 0)
+        return torch.any(self.angle != 0).item()
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
         num_splits = torch.ceil(torch.max(self.length) / resolution).int()

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -190,7 +190,7 @@ class Quadrupole(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.k1 != 0)
+        return torch.any(self.k1 != 0).item()
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
         num_splits = torch.ceil(torch.max(self.length) / resolution).int()

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -104,8 +104,9 @@ class Solenoid(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.k != 0)
+        return torch.any(self.k != 0).item()
 
+    @property
     def is_skippable(self) -> bool:
         return True
 

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -74,7 +74,7 @@ class TransverseDeflectingCavity(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.voltage != 0)
+        return torch.any(self.voltage != 0).item()
 
     @property
     def is_skippable(self) -> bool:

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -70,7 +70,7 @@ class VerticalCorrector(Element):
 
     @property
     def is_active(self) -> bool:
-        return torch.any(self.angle != 0)
+        return torch.any(self.angle != 0).item()
 
     def split(self, resolution: torch.Tensor) -> list[Element]:
         num_splits = torch.ceil(torch.max(self.length) / resolution).int()

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+
+import cheetah
+
+ELEMENT_CLASSES_REQUIRING_ARGS = {
+    cheetah.Cavity: {"length": torch.tensor(1.0)},
+    cheetah.CustomTransferMap: {"predefined_transfer_map": torch.eye(7)},
+    cheetah.Drift: {"length": torch.tensor(1.0)},
+    cheetah.Dipole: {"length": torch.tensor(1.0)},
+    cheetah.HorizontalCorrector: {"length": torch.tensor(1.0)},
+    cheetah.Quadrupole: {"length": torch.tensor(1.0)},
+    cheetah.Segment: {"elements": [cheetah.Drift(length=torch.tensor(1.0))]},
+    cheetah.Solenoid: {"length": torch.tensor(1.0)},
+    cheetah.SpaceChargeKick: {"effect_length": torch.tensor(1.0)},
+    cheetah.TransverseDeflectingCavity: {"length": torch.tensor(1.0)},
+    cheetah.Undulator: {"length": torch.tensor(1.0)},
+    cheetah.VerticalCorrector: {"length": torch.tensor(1.0)},
+}
+
+
+@pytest.mark.parametrize("ElementClass", cheetah.Element.__subclasses__())
+def test_element_subclasses_is_active_boolean(ElementClass):
+    """
+    Test that the `is_active` property of all `Element` subclasses returns a boolean if
+    the element class has an `is_active` property.
+    """
+    if ElementClass in ELEMENT_CLASSES_REQUIRING_ARGS:
+        element = ElementClass(**ELEMENT_CLASSES_REQUIRING_ARGS[ElementClass])
+    else:
+        element = ElementClass()
+
+    assert not hasattr(element, "is_active") or isinstance(element.is_active, bool)
+
+
+@pytest.mark.parametrize("ElementClass", cheetah.Element.__subclasses__())
+def test_all_element_subclasses_is_skippable_boolean(ElementClass):
+    """
+    Test that the `is_skippable` property of all `Element` subclasses returns a boolean.
+    """
+    if ElementClass in ELEMENT_CLASSES_REQUIRING_ARGS:
+        element = ElementClass(**ELEMENT_CLASSES_REQUIRING_ARGS[ElementClass])
+    else:
+        element = ElementClass()
+
+    assert isinstance(element.is_skippable, bool)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a test that checks that `is_active` (if an element has it) and `is_skippable` are always properties and of boolean type. Some elements require some arguments to be passed, so the test is designed to fail when a new element is added, such that properly extending the test for that element cannot be forgotten.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

Fixes #345, where the `@property` decorator was missing on `Solenoid.is_skippable`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
