### PR TITLE
Handle Elegant `;` line ending

### DIFF
--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -428,6 +428,10 @@ def convert_lattice_to_cheetah(
     merged_lines = merge_delimiter_continued_lines(
         merged_lines, delimiter="{", remove_delimiter=False
     )
+
+    #strip EOL char (;) from final merged lines
+    merged_lines = [line.strip(";") for line in merged_lines]
+    
     assert len(merged_lines) <= len(
         lines
     ), "Merging lines should never produce more lines than there were before."

--- a/tests/resources/fodo.lte
+++ b/tests/resources/fodo.lte
@@ -1,8 +1,8 @@
-c: charge,total=0.25e-9
-q1: quad,l=0.1,k1=1.5 
-q2: quad,l=0.2,k1=-3
-d1: drift,l=1
-d2: drift ,l=2
-s1: sben, l=0.3,e1=0.25
+c: charge,total=0.25e-9;
+q1: quad,l=0.1,k1=1.5;
+q2: quad,l=0.2,k1=-3;
+d1: drift,l=1;
+d2: drift ,l=2;
+s1: sben, l=0.3,e1=0.25;
 m1: mark
 fodo: line=(c,q1,d1,m1,s1,d1,q2,d2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just adds stripping of `;` from elegant line endings and modifies the test to reflect it.
<!--- Describe your changes in detail -->

## Motivation and Context
The CLARA/FEBE elegant lattice has these line endings and it otherwise causes parsing errors.
Closes #383

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [X] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [X] I have ensured that all `pytest` tests pass (**required**).
- [X] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
Draft while I complete the checklist