### PR TITLE
Plot Twiss parameter after each element

### DIFF
--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -594,7 +594,7 @@ class Segment(Element):
         """Plot twiss parameters along the segment."""
         longitudinal_beams = [incoming]
         s_positions = [torch.tensor(0.0)]
-        for element in self.elements:
+        for element in self.flattened().elements:
             if torch.all(element.length == 0):
                 continue
 


### PR DESCRIPTION
This slightly modifies the function `plot_twiss` so as to plot the Twiss parameter after each element of a `segment`, even when the `segment` is made of several sub-segments.

## Motivation and Context

When a segment is made of several sub-segments, the function `plot_twiss` currently only considers the Twiss parameter at the end of each sub-segments, instead of at the end of each elements in the underlying sub-segments. This leads to under-sampled and non-representative plots of the beta function.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).
