### PR TITLE
[WIP] Parse kicker when reading Elegant files

### DIFF
--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -309,6 +309,26 @@ def convert_element(
                 frequency=torch.tensor(parsed["frequency"], **factory_kwargs),
                 name=name,
             )
+        elif parsed["element_type"] == "kicker":
+            validate_understood_properties(
+                ["element_type", "hkick", "vkick"],
+                parsed
+            )
+            return cheetah.Segment(
+                elements=[
+                    cheetah.HorizontalCorrector(
+                        length=torch.tensor(parsed.get("l", 0.0)/2, **factory_kwargs),
+                        angle=torch.tensor(parsed["hkick"], **factory_kwargs),
+                        name=name + "_hkick",
+                    ),
+                    cheetah.VerticalCorrector(
+                        length=torch.tensor(parsed.get("l", 0.0)/2, **factory_kwargs),
+                        angle=torch.tensor(parsed["vkick"], **factory_kwargs),
+                        name=name + "_vkick",
+                    ),
+                ],
+                name=name + "_segment",
+            )
         elif parsed["element_type"] in ["sben", "csbend"]:
             validate_understood_properties(
                 ["element_type", "l", "angle", "k1", "e1", "e2", "tilt", "group"],


### PR DESCRIPTION
Allow Cheetah to parse KICKER elements in Elegant files

## Description

Elegant files sometimes contains Kickers:
https://ops.aps.anl.gov/manuals/elegant_latest/elegantsu158.html#x169-17000010.49
My understanding is that this corresponds to Cheetah's `HorizontalCorrector`/`VerticalCorrector`. I updated the function `convert_element` to enable it to parse kickers

## Motivation and Context

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
