### PR TITLE
Make sure that the clone method preserves the tracking_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fix issue where semicolons after an Elegant line would cause parsing to fail (see #383) (@amylizzle)
+- Fix issue where `Quadrupole.tracking_method` was not preserved on cloning (see #404) (@RemiLehe, @jank324)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -218,7 +218,13 @@ class Quadrupole(Element):
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "k1", "misalignment", "tilt", "tracking_method"]
+        return super().defining_features + [
+            "length",
+            "k1",
+            "misalignment",
+            "tilt",
+            "tracking_method",
+        ]
 
     def __repr__(self) -> str:
         return (

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -218,7 +218,7 @@ class Quadrupole(Element):
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "k1", "misalignment", "tilt"]
+        return super().defining_features + ["length", "k1", "misalignment", "tilt", "tracking_method"]
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_quadrupole.py
+++ b/tests/test_quadrupole.py
@@ -236,3 +236,27 @@ def test_tracking_method_vectorization(tracking_method):
     assert outgoing.sigma_p.shape == (3, 2)
     assert outgoing.energy.shape == torch.Size([])
     assert outgoing.total_charge.shape == torch.Size([])
+
+
+def test_quadrupole_clone_tracking_method():
+    """
+    Test that the tracking_method is preserved when cloning a Quadrupole.
+    """
+    # Create a quadrupole with bmadx tracking method
+    quadrupole = Quadrupole(
+        length=torch.tensor(1.0),
+        k1=torch.tensor(1.0),
+        tracking_method='bmadx'
+    )
+
+    # Clone the quadrupole
+    cloned = quadrupole.clone()
+
+    # Verify that tracking_method is preserved
+    assert cloned.tracking_method == 'bmadx'
+
+    # Also verify that other attributes are preserved
+    assert torch.allclose(cloned.length, quadrupole.length)
+    assert torch.allclose(cloned.k1, quadrupole.k1)
+    assert torch.allclose(cloned.misalignment, quadrupole.misalignment)
+    assert torch.allclose(cloned.tilt, quadrupole.tilt)

--- a/tests/test_quadrupole.py
+++ b/tests/test_quadrupole.py
@@ -238,23 +238,19 @@ def test_tracking_method_vectorization(tracking_method):
     assert outgoing.total_charge.shape == torch.Size([])
 
 
-def test_quadrupole_clone_tracking_method():
+@pytest.mark.parametrize("tracking_method", ["cheetah", "bmadx"])
+def test_quadrupole_clone_tracking_method(tracking_method):
     """
     Test that the tracking_method is preserved when cloning a Quadrupole.
     """
     # Create a quadrupole with bmadx tracking method
     quadrupole = Quadrupole(
-        length=torch.tensor(1.0), k1=torch.tensor(1.0), tracking_method="bmadx"
+        length=torch.tensor(1.0), k1=torch.tensor(1.0), tracking_method=tracking_method
     )
 
     # Clone the quadrupole
     cloned = quadrupole.clone()
 
     # Verify that tracking_method is preserved
-    assert cloned.tracking_method == "bmadx"
-
-    # Also verify that other attributes are preserved
-    assert torch.allclose(cloned.length, quadrupole.length)
-    assert torch.allclose(cloned.k1, quadrupole.k1)
-    assert torch.allclose(cloned.misalignment, quadrupole.misalignment)
-    assert torch.allclose(cloned.tilt, quadrupole.tilt)
+    assert cloned.tracking_method == quadrupole.tracking_method
+    assert cloned.tracking_method == tracking_method

--- a/tests/test_quadrupole.py
+++ b/tests/test_quadrupole.py
@@ -244,16 +244,14 @@ def test_quadrupole_clone_tracking_method():
     """
     # Create a quadrupole with bmadx tracking method
     quadrupole = Quadrupole(
-        length=torch.tensor(1.0),
-        k1=torch.tensor(1.0),
-        tracking_method='bmadx'
+        length=torch.tensor(1.0), k1=torch.tensor(1.0), tracking_method="bmadx"
     )
 
     # Clone the quadrupole
     cloned = quadrupole.clone()
 
     # Verify that tracking_method is preserved
-    assert cloned.tracking_method == 'bmadx'
+    assert cloned.tracking_method == "bmadx"
 
     # Also verify that other attributes are preserved
     assert torch.allclose(cloned.length, quadrupole.length)


### PR DESCRIPTION
Closes #403 

The issue was that the `clone()` method in the Element class uses the `defining_features` list to determine which attributes to copy. Since `tracking_method` wasn't in this list, it wasn't being copied during cloning, causing it to default to `"cheetah"` in the new instance.