### PR TITLE
[WIP] Fix vertical misalignment in screen object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix Twiss plot to plot samples also after elements in nested (see #388) (@RemiLehe)
 - Fix issue where generating screen images did not work on GPU because `Screen.pixel_bin_centers` was not on the same device (see #372) (@roussel-ryan, @jank324)
 - Fix issue where `Quadrupole.tracking_method` was not preserved on cloning (see #404) (@RemiLehe, @jank324)
+- The vertical screen misalignment is now correctly applied to `y` instead of `px` (see #405) (@RemiLehe)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -182,7 +182,7 @@ class Screen(Element):
                 copy_of_incoming.particles[..., 0] -= self.misalignment[
                     ..., 0
                 ].unsqueeze(-1)
-                copy_of_incoming.particles[..., 1] -= self.misalignment[
+                copy_of_incoming.particles[..., 2] -= self.misalignment[
                     ..., 1
                 ].unsqueeze(-1)
 


### PR DESCRIPTION
The vertical screen misalignment was applied to coordinate 1 (i.e. `px`) instead of coordinate 2 (i.e. `y`).