### PR TITLE
fix `Screen` device issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Screen` device issues when using gpu (see #428) (@jp-ga)
+
 ### 🐆 Other
 
 ### 🌟 First Time Contributors

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -185,10 +185,10 @@ class Screen(Element):
 
                 copy_of_incoming.particles[..., 0] -= self.misalignment[
                     ..., 0
-                ].unsqueeze(-1)
+                ].unsqueeze(-1).to(copy_of_incoming.particles)
                 copy_of_incoming.particles[..., 2] -= self.misalignment[
                     ..., 1
-                ].unsqueeze(-1)
+                ].unsqueeze(-1).to(copy_of_incoming.particles)
 
             self.set_read_beam(copy_of_incoming)
 
@@ -296,8 +296,8 @@ class Screen(Element):
                 image = kde_histogram_2d(
                     x1=broadcasted_x,
                     x2=broadcasted_y,
-                    bins1=self.pixel_bin_centers[0],
-                    bins2=self.pixel_bin_centers[1],
+                    bins1=self.pixel_bin_centers[0].to(read_beam.x),
+                    bins2=self.pixel_bin_centers[1].to(read_beam.x),
                     bandwidth=self.kde_bandwidth,
                     weights=broadcasted_weights,
                 )

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -183,12 +183,16 @@ class Screen(Element):
                 )
                 copy_of_incoming.particles = broadcasted_particles.clone()
 
-                copy_of_incoming.particles[..., 0] -= self.misalignment[
-                    ..., 0
-                ].unsqueeze(-1).to(copy_of_incoming.particles)
-                copy_of_incoming.particles[..., 2] -= self.misalignment[
-                    ..., 1
-                ].unsqueeze(-1).to(copy_of_incoming.particles)
+                copy_of_incoming.particles[..., 0] -= (
+                    self.misalignment[..., 0]
+                    .unsqueeze(-1)
+                    .to(copy_of_incoming.particles)
+                )
+                copy_of_incoming.particles[..., 2] -= (
+                    self.misalignment[..., 1]
+                    .unsqueeze(-1)
+                    .to(copy_of_incoming.particles)
+                )
 
             self.set_read_beam(copy_of_incoming)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
After PR #395 , `Screen` element mixes gpu and cpu devices.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #427 
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [x ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
