### PR TITLE
441 elegant elements without length cause error in conversion

### DIFF
--- a/cheetah/converters/elegant.py
+++ b/cheetah/converters/elegant.py
@@ -47,7 +47,7 @@ def convert_element(
             # The group property does not have an analoge in Cheetah, so it is neglected
             validate_understood_properties(["element_type", "l", "group"], parsed)
             return cheetah.Solenoid(
-                length=torch.tensor(parsed["l"], **factory_kwargs), name=name
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs), name=name
             )
         elif parsed["element_type"] in ["hkick", "hkic"]:
             validate_understood_properties(
@@ -163,8 +163,8 @@ def convert_element(
                 parsed,
             )
             return cheetah.Quadrupole(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
-                k1=torch.tensor(parsed["k1"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
+                k1=torch.tensor(parsed.get("k1", 0.0), **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
             )
@@ -174,8 +174,8 @@ def convert_element(
                 parsed,
             )
             return cheetah.Sextupole(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
-                k2=torch.tensor(parsed["k2"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
+                k2=torch.tensor(parsed.get("k2", 0.0), **factory_kwargs),
                 tilt=torch.tensor(parsed.get("tilt", 0.0), **factory_kwargs),
                 name=name,
             )
@@ -185,12 +185,16 @@ def convert_element(
                 return cheetah.Segment(
                     elements=[
                         cheetah.Drift(
-                            length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
+                            length=torch.tensor(
+                                parsed.get("l", 0.0) / 2, **factory_kwargs
+                            ),
                             name=name + "_predrift",
                         ),
                         cheetah.BPM(name=name),
                         cheetah.Drift(
-                            length=torch.tensor(parsed["l"] / 2, **factory_kwargs),
+                            length=torch.tensor(
+                                parsed.get("l", 0.0) / 2, **factory_kwargs
+                            ),
                             name=name + "_postdrift",
                         ),
                     ],
@@ -224,7 +228,7 @@ def convert_element(
             )
 
             return cheetah.CustomTransferMap(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 predefined_transfer_map=R,
                 name=name,
             )
@@ -247,12 +251,12 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.Cavity(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
-                voltage=torch.tensor(parsed["volt"], **factory_kwargs),
-                frequency=torch.tensor(parsed["freq"], **factory_kwargs),
+                phase=torch.tensor(parsed.get("phase", 0.0) - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed.get("volt", 0.0), **factory_kwargs),
+                frequency=torch.tensor(parsed.get("freq", 0.0), **factory_kwargs),
                 name=name,
             )
         elif parsed["element_type"] == "rfcw":
@@ -289,12 +293,12 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.Cavity(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
-                voltage=torch.tensor(parsed["volt"], **factory_kwargs),
-                frequency=torch.tensor(parsed["freq"], **factory_kwargs),
+                phase=torch.tensor(parsed.get("phase", 0.0) - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed.get("volt", 0.0), **factory_kwargs),
+                frequency=torch.tensor(parsed.get("freq", 0.0), **factory_kwargs),
                 name=name,
             )
         elif parsed["element_type"] == "rfdf":
@@ -312,12 +316,12 @@ def convert_element(
 
             # TODO Properly handle all parameters
             return cheetah.TransverseDeflectingCavity(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 # Elegant defines 90° as the phase of maximum acceleration,
                 # while Cheetah uses 0°. We therefore add a phase offset to compensate.
-                phase=torch.tensor(parsed["phase"] - 90, **factory_kwargs),
-                voltage=torch.tensor(parsed["voltage"], **factory_kwargs),
-                frequency=torch.tensor(parsed["frequency"], **factory_kwargs),
+                phase=torch.tensor(parsed.get("phase", 0.0) - 90, **factory_kwargs),
+                voltage=torch.tensor(parsed.get("voltage", 0.0), **factory_kwargs),
+                frequency=torch.tensor(parsed.get("frequency", 0.0), **factory_kwargs),
                 name=name,
             )
         elif parsed["element_type"] in ["sben", "csbend"]:
@@ -326,7 +330,7 @@ def convert_element(
                 parsed,
             )
             return cheetah.Dipole(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
                 k1=torch.tensor(parsed.get("k1", 0.0), **factory_kwargs),
                 dipole_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),
@@ -340,7 +344,7 @@ def convert_element(
                 parsed,
             )
             return cheetah.RBend(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
                 rbend_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),
                 rbend_e2=torch.tensor(parsed.get("e2", 0.0), **factory_kwargs),
@@ -380,7 +384,7 @@ def convert_element(
                 parsed,
             )
             return cheetah.Dipole(
-                length=torch.tensor(parsed["l"], **factory_kwargs),
+                length=torch.tensor(parsed.get("l", 0.0), **factory_kwargs),
                 angle=torch.tensor(parsed.get("angle", 0.0), **factory_kwargs),
                 k1=torch.tensor(parsed.get("k1", 0.0), **factory_kwargs),
                 dipole_e1=torch.tensor(parsed.get("e1", 0.0), **factory_kwargs),

--- a/tests/resources/fodo.lte
+++ b/tests/resources/fodo.lte
@@ -6,5 +6,6 @@ d2: drift ,l=2.0 # gap: 10.0
 b1: sben, l=0.3,e1=0.25
 s1: sext,l=0.2,k2=-87.1;
 csrbend: csrcsbend, l = 0.200981, bins = 4096, csr = 1, isr = 1, n_slices = 8, synch_rad = 1, integration_order = 4, nonlinear = 1, sg_halfwidth = 1, edge_order = 2, edge1_effects = 1, edge2_effects = 1, angle = 0.113612175128842, fint = 0.4, e2 = 0.113612175128842, hgap = 0.005, high_frequency_cutoff0 = 0.2, high_frequency_cutoff1 = 0.25, k1 = 0;
+d3: drift
 m1: mark
-fodo: line=(c,q1,d1,m1,b1,d1,q2,d2,s1,csrbend)
+fodo: line=(c,q1,d1,m1,b1,d1,q2,d2,s1,csrbend,d3,m1)

--- a/tests/test_elegant_conversion.py
+++ b/tests/test_elegant_conversion.py
@@ -38,6 +38,10 @@ def test_fodo():
                 dipole_e2=torch.tensor(0.113612175128842),
                 k1=torch.tensor(0.0),
             ),
+            # Test normal element with default length
+            cheetah.Drift(name="d3", length=torch.tensor(0.0)),
+            # Test marker without length attribute
+            cheetah.Marker(name="m1"),
         ],
         name="fodo",
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make the elegant converter more robust by providing default values (0.0) of some element paramters, such as length, voltage, phase, and frequency.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
