### PR TITLE
Allow gradient propagating in `ParticleBeam.from_parameter` initialization

### DIFF
--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -343,7 +343,7 @@ class ParticleBeam(Beam):
             for sample_mu, sample_cov in zip(mu.view(-1, 6), cov.view(-1, 6, 6))
         ]
         particles[..., :6] = torch.stack(
-            [distribution.sample((num_particles,)) for distribution in distributions],
+            [distribution.rsample((num_particles,)) for distribution in distributions],
             dim=0,
         ).view(*vector_shape, num_particles, 6)
 

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -171,3 +171,20 @@ def test_parameters_at_initialization():
     assert list(dipole_initial.parameters()) == list(dipole_assigned.parameters())
     assert len(list(dipole_initial.parameters())) == 1
     assert parameter in dipole_initial.parameters()
+
+
+def test_requiregrad_at_particlebeam_initialization():
+    """
+    Test that passing a torch.tensor with requires_grad=True at
+    ParticleBeam.from_parameters initialization creates a beam with proper
+    gradient tracking.
+    """
+    beam = cheetah.ParticleBeam.from_parameters(
+        num_particles=100,
+        mu_x=torch.tensor(0.0, requires_grad=True),
+        mu_y=torch.tensor(0.0, requires_grad=True),
+        energy=torch.tensor(1e6),
+    )
+
+    assert beam.x.requires_grad
+    assert beam.y.requires_grad


### PR DESCRIPTION
Change the pytorch `sample()` to `rsample()` to use the reparametrization method, allowing passing tensors with `requires_grad=True` in the `ParticleBeam.from_parameter` initialization method.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
