### PR TITLE
Correct beam duration in space-charge test (only affects non-relativistic case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐛 Bug fixes
 
 - Fix issue where `Dipole` with `tracking_method="bmadx"` and `angle=0.0` would output `NaN` values as a result of a division by zero (see #434) (@jank324)
+- Fix issue in CI space-charge tests (incorrect beam duration in non-relativistic case) (see #446) (@RemiLehe)
 
 ### 🐆 Other
 

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -217,9 +217,7 @@ def test_gradient_value_backward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0
-        / gamma
-        / beta,  # Duration of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),
@@ -283,9 +281,7 @@ def test_gradient_value_forward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0
-        / gamma
-        / beta,  # Duration of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -9,7 +9,8 @@ import cheetah
 from cheetah.utils import compute_relativistic_factors
 
 
-# Run the test below for both the ultra-relativistic case (250 MeV) and the non-relativistic case (1 MeV).
+# Run the test below for both the ultra-relativistic case
+# (250 MeV) and the non-relativistic case (1 MeV).
 @pytest.mark.parametrize("energy", [torch.tensor(2.5e8), torch.tensor(1e6)])
 def test_cold_uniform_beam_expansion(energy):
     """

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -8,6 +8,7 @@ import pytest
 import cheetah
 from cheetah.utils import compute_relativistic_factors
 
+
 # Run the test below for both the ultra-relativistic case (250 MeV) and the non-relativistic case (1 MeV).
 @pytest.mark.parametrize("energy", [torch.tensor(2.5e8), torch.tensor(1e6)])
 def test_cold_uniform_beam_expansion(energy):
@@ -216,7 +217,9 @@ def test_gradient_value_backward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma / beta,  # Duration of the beam in s direction in the lab frame
+        radius_tau=R0
+        / gamma
+        / beta,  # Duration of the beam in s direction in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),
@@ -280,7 +283,9 @@ def test_gradient_value_forward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma / beta,  # Duration of the beam in s direction in the lab frame
+        radius_tau=R0
+        / gamma
+        / beta,  # Duration of the beam in s direction in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -35,7 +35,7 @@ def test_cold_uniform_beam_expansion():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma,  # Radius of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),
@@ -90,7 +90,7 @@ def test_vectorized_cold_uniform_beam_expansion():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma,  # Radius of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),
@@ -133,6 +133,7 @@ def test_vectorized():
         / constants.elementary_charge
     )
     gamma = energy / rest_energy
+    beta = torch.sqrt(1 - 1 / gamma**2)
 
     incoming = cheetah.ParticleBeam.uniform_3d_ellipsoid(
         num_particles=torch.tensor(10_000),
@@ -140,8 +141,8 @@ def test_vectorized():
         energy=energy.expand([3, 2]),
         radius_x=R0.expand([3, 2]),
         radius_y=R0.expand([3, 2]),
-        radius_tau=R0.expand([3, 2]) / gamma,
-        # Radius of the beam in s direction in the lab frame
+        radius_tau=R0.expand([3, 2]) / gamma / beta,
+        # Duration of the beam in the lab frame
         sigma_px=torch.tensor(1e-15).expand([3, 2]),
         sigma_py=torch.tensor(1e-15).expand([3, 2]),
         sigma_p=torch.tensor(1e-15).expand([3, 2]),
@@ -214,7 +215,7 @@ def test_gradient_value_backward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma,  # Radius of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in s direction in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),
@@ -278,7 +279,7 @@ def test_gradient_value_forward_ad():
         energy=energy,
         radius_x=R0,
         radius_y=R0,
-        radius_tau=R0 / gamma,  # Radius of the beam in s direction in the lab frame
+        radius_tau=R0 / gamma / beta,  # Duration of the beam in s direction in the lab frame
         sigma_px=torch.tensor(1e-15),
         sigma_py=torch.tensor(1e-15),
         sigma_p=torch.tensor(1e-15),

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -3,12 +3,14 @@ import torch.autograd.forward_ad as fwAD
 from scipy import constants
 from scipy.constants import physical_constants
 from torch import nn
+import pytest
 
 import cheetah
 from cheetah.utils import compute_relativistic_factors
 
-
-def test_cold_uniform_beam_expansion():
+# Run the test below for both the ultra-relativistic case (250 MeV) and the non-relativistic case (1 MeV).
+@pytest.mark.parametrize("energy", [torch.tensor(2.5e8), torch.tensor(1e6)])
+def test_cold_uniform_beam_expansion(energy):
     """
     Tests that that a cold uniform beam doubles in size in both dimensions when
     travelling through a drift section with space_charge. (cf ImpactX test:
@@ -18,7 +20,6 @@ def test_cold_uniform_beam_expansion():
     """
     # Simulation parameters
     R0 = torch.tensor(0.001)
-    energy = torch.tensor(2.5e8)
     rest_energy = torch.tensor(
         constants.electron_mass
         * constants.speed_of_light**2

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -1,9 +1,9 @@
+import pytest
 import torch
 import torch.autograd.forward_ad as fwAD
 from scipy import constants
 from scipy.constants import physical_constants
 from torch import nn
-import pytest
 
 import cheetah
 from cheetah.utils import compute_relativistic_factors


### PR DESCRIPTION
The way the space-charge tests where written was incorrect for the non-relativistic case.

## Description

The space-charge tests represents a situation where the beam has the same size in `x`, `y` and `z`, in the beam rest frame. (See Free Expansion of a Cold Uniform Bunch in https://accelconf.web.cern.ch/hb2023/papers/thbp44.pdf.) But since `cheetah` works with the beam duration, we need to correctly calculate the corresponding beam duration. 

There was a missing `beta` factor in the previous formula. This only matters for non-relativistic beams.