### PR TITLE
implement zero phase tdc for parameter beam tracking

### DIFF
--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 import matplotlib.pyplot as plt
+from cheetah.track_methods import base_rmatrix
 import torch
 from matplotlib.patches import Rectangle
 from scipy.constants import speed_of_light
@@ -98,9 +99,7 @@ class TransverseDeflectingCavity(Element):
         :return: Beam exiting the element.
         """
         if self.tracking_method == "cheetah":
-            raise NotImplementedError(
-                "Cheetah transverse deflecting cavity tracking is not yet implemented."
-            )
+            return super().track(incoming)
         elif self.tracking_method == "bmadx":
             assert isinstance(
                 incoming, ParticleBeam
@@ -111,6 +110,45 @@ class TransverseDeflectingCavity(Element):
                 f"Invalid tracking method {self.tracking_method}. "
                 + "Supported methods are 'cheetah' and 'bmadx'."
             )
+        
+    def transfer_map(self, energy: torch.Tensor, species: Beam) -> torch.Tensor:
+        """
+        Compute the transfer map for a thick lens transverse deflecting cavity.
+        Use drift-kick-drift method for tracking.
+
+        Note: This method only works for zero phase.
+
+        :param energy: Energy of the beam in eV.
+        :param species: Species of the beam.
+        :return: Transfer map for the element.
+        """
+        assert torch.allclose(self.phase, torch.zeros_like(self.phase)), "Phase must be zero for transfer map calculation."
+
+        # calculate drift transfer matrix
+        R_drift = base_rmatrix(
+            length=self.length / 2.0,
+            k1=torch.zeros_like(self.length),
+            hx=torch.zeros_like(self.length),
+            species=species,
+            tilt=self.tilt,
+            energy=energy,
+        )
+        
+        # calculate kick transfer matrix
+        k = 2 * torch.pi * self.frequency * self.voltage / speed_of_light / energy
+        vector_shape = torch.broadcast_shapes(
+            self.length.shape, k.shape, energy.shape
+        )
+        R_kick = torch.eye(7, dtype=self.length.dtype, device=self.length.device).repeat(*vector_shape, 1, 1)
+
+        # note that the longidutinal coordinate in cheetah is negative normal convention
+        R_kick[...,1,4] = -k
+        R_kick[...,5,0] = k
+
+        # calculate total transfer matrix
+        R = torch.matmul(R_kick, R_drift)
+        R = torch.matmul(R_drift, R)
+        return R
 
     def _track_bmadx(self, incoming: ParticleBeam) -> ParticleBeam:
         """


### PR DESCRIPTION
Implements zero-phase, first order transverse deflecting cavity tracking for ParameterBeam class using thick lens transport matrix

## Description

This pull request introduces functionality for tracking and transfer map computation in the `TransverseDeflectingCavity` class using the `"cheetah"` tracking method. It also adds a corresponding unit test to ensure consistency with the `"bmadx"` tracking method. Below are the most important changes grouped by theme:

### New functionality for `"cheetah"` tracking:

* Added a `transfer_map` method to compute the transfer map for a thick lens transverse deflecting cavity using a drift-kick-drift approach. This method restricts usage to zero phase and calculates drift and kick matrices before combining them into the total transfer matrix. (`cheetah/accelerator/transverse_deflecting_cavity.py`, [cheetah/accelerator/transverse_deflecting_cavity.pyR114-R152](diffhunk://#diff-580bd7f5ce81e567ed71eaf064f024f15a4ac97eb928bab7899b78b2367e43d6R114-R152))
* Updated the `track` method to support the `"cheetah"` tracking method by delegating to the parent class implementation. Previously, this raised a `NotImplementedError`. (`cheetah/accelerator/transverse_deflecting_cavity.py`, [cheetah/accelerator/transverse_deflecting_cavity.pyL101-R102](diffhunk://#diff-580bd7f5ce81e567ed71eaf064f024f15a4ac97eb928bab7899b78b2367e43d6L101-R102))

### Unit tests for `"cheetah"` tracking:

* Added a new test, `test_transverse_deflecting_cavity_cheetah_tracking`, to verify that the results of the `"cheetah"` tracking method match those of the `"bmadx"` method. The test checks the transfer map and performs tracking on a sample beam. (`tests/test_transverse_deflecting_cavity.py`, [tests/test_transverse_deflecting_cavity.pyR41-R91](diffhunk://#diff-664b15d8db6029ececb6df665889b0a54e7532a24a0376422c1a7f89e559dca0R41-R91))


## Motivation and Context

Looking to do scalarized uncertainty quantification using RMS beam moments with transverse deflecting cavities.

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ X ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [X  ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
