### PR TITLE
Improve the cov calculation in ParticleBeam to alllow batched calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix issue that `base_rmatrix` has large error for small `k1` values even for double precision (see #469) (@cr-xu)
-- Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams (see #471) (@cr-xu)
+- Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams (see #471) (@cr-xu, @jank324)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an issue that batched Particlebeam cannot be converted using `as_parameter_beam`, rework the covariance calculation (see #471) (@cr-xu)
+
 ### 🐆 Other
 
 ### 🌟 First Time Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix an issue that batched Particlebeam cannot be converted using `as_parameter_beam`, rework the covariance calculation (see #471) (@cr-xu)
+- Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams (see #471) (@cr-xu)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@
 
 ### 🐛 Bug fixes
 
-<<<<<<< 470-particlebeamas_parameter_beam-breaks-for-batched-particlebeam
-- Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams (see #471) (@cr-xu)
-=======
 - Fix issue that `base_rmatrix` has large error for small `k1` values even for double precision (see #469) (@cr-xu)
->>>>>>> master
+- Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams (see #471) (@cr-xu)
 
 ### 🐆 Other
 

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -1041,7 +1041,7 @@ class ParticleBeam(Beam):
             mu=(self.particles * self.survival_probabilities.unsqueeze(-1)).sum(dim=-2)
             / self.survival_probabilities.sum(),
             cov=unbiased_weighted_covariance_matrix(
-                self.particles, weights=self.survival_probabilities, dim=-2
+                self.particles, weights=self.survival_probabilities
             ),
             energy=self.energy,
             total_charge=self.total_charge,

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -555,7 +555,7 @@ class ParticleBeam(Beam):
             dtype=dtype,
         )
 
-        # Extract the batch dimension of the beam
+        # Extract the vector dimension of the beam
         vector_shape = beam.sigma_x.shape
 
         # Generate random particles in unit sphere in polar coodinates
@@ -858,7 +858,7 @@ class ParticleBeam(Beam):
         NOTE: openPMD uses boolean particle status flags, i.e. alive or dead. Cheetah's
             survival probabilities are converted to status flags by thresholding at 0.5.
 
-        NOTE: At the moment this method only supports non-batched particles
+        NOTE: At the moment this method only supports non-vectorised particle
             distributions.
 
         :return: openPMD `ParticleGroup` object with the `ParticleBeam`'s particles.
@@ -871,9 +871,11 @@ class ParticleBeam(Beam):
                 installed."""
             )
 
-        # For now only support non-batched particles
+        # For now only support non-vectorised particle distributions
         if len(self.particles.shape) != 2:
-            raise ValueError("Only non-batched particles are supported.")
+            raise ValueError(
+                "Only non-vectorised particle distributions are supported."
+            )
 
         px = self.px * self.p0c
         py = self.py * self.p0c

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -1039,7 +1039,9 @@ class ParticleBeam(Beam):
 
         return ParameterBeam(
             mu=self.particles.mean(dim=-2),
-            cov=self.cov_matrix,
+            cov=unbiased_weighted_covariance_matrix(
+                self.particles, weights=self.survival_probabilities, dim=-2
+            ),
             energy=self.energy,
             total_charge=self.total_charge,
             device=self.particles.device,
@@ -1724,17 +1726,6 @@ class ParticleBeam(Beam):
         """
         return unbiased_weighted_covariance(
             self.tau, self.p, weights=self.survival_probabilities, dim=-1
-        )
-
-    @property
-    def cov_matrix(self) -> torch.Tensor:
-        """
-        Returns the whole covariance matrix of the beam,
-        weighted by the survival probability of the particles.
-        The covariance matrix is of shape (..., 7, 7)
-        """
-        return unbiased_weighted_covariance_matrix(
-            self.particles, weights=self.survival_probabilities, dim=-2
         )
 
     @property

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -14,6 +14,7 @@ from cheetah.utils import (
     elementwise_linspace,
     format_axis_with_prefixed_unit,
     unbiased_weighted_covariance,
+    unbiased_weighted_covariance_matrix,
     unbiased_weighted_std,
     verify_device_and_dtype,
 )
@@ -1036,7 +1037,7 @@ class ParticleBeam(Beam):
 
         return ParameterBeam(
             mu=self.particles.mean(dim=-2),
-            cov=torch.cov(self.particles.transpose(-2, -1)),
+            cov=self.cov_matrix,
             energy=self.energy,
             total_charge=self.total_charge,
             device=self.particles.device,
@@ -1721,6 +1722,17 @@ class ParticleBeam(Beam):
         """
         return unbiased_weighted_covariance(
             self.tau, self.p, weights=self.survival_probabilities, dim=-1
+        )
+
+    @property
+    def cov_matrix(self) -> torch.Tensor:
+        """
+        Returns the whole covariance matrix of the beam,
+        weighted by the survival probability of the particles.
+        The covariance matrix is of shape (..., 7, 7)
+        """
+        return unbiased_weighted_covariance_matrix(
+            self.particles, weights=self.survival_probabilities, dim=-2
         )
 
     @property

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -1038,7 +1038,8 @@ class ParticleBeam(Beam):
         from cheetah.particles.parameter_beam import ParameterBeam  # No circular import
 
         return ParameterBeam(
-            mu=self.particles.mean(dim=-2),
+            mu=(self.particles * self.survival_probabilities.unsqueeze(-1)).sum(dim=-2)
+            / self.survival_probabilities.sum(),
             cov=unbiased_weighted_covariance_matrix(
                 self.particles, weights=self.survival_probabilities, dim=-2
             ),

--- a/cheetah/utils/__init__.py
+++ b/cheetah/utils/__init__.py
@@ -10,6 +10,7 @@ from .plot import (  # noqa: F401
 )
 from .statistics import (  # noqa: F401
     unbiased_weighted_covariance,
+    unbiased_weighted_covariance_matrix,
     unbiased_weighted_std,
     unbiased_weighted_variance,
 )

--- a/cheetah/utils/statistics.py
+++ b/cheetah/utils/statistics.py
@@ -73,10 +73,12 @@ def unbiased_weighted_covariance_matrix(
     :param dim: Dimension along which to compute the covariance.
     :return: Unbiased weighted covariance matrix.
     """
-    normalized_weights = weights / torch.sum(weights)
+    normalized_weights = weights / weights.unsqueeze(-1).sum(dim)
     weighted_means = torch.sum(inputs * normalized_weights.unsqueeze(-1), dim)
     centered_inputs = inputs - weighted_means.unsqueeze(dim)
-    correction_factor = 1 - (torch.sum(normalized_weights**2) / torch.sum(weights))
+    correction_factor = 1 - (
+        torch.sum(normalized_weights**2) / weights.unsqueeze(-1).sum(dim)
+    )
     covariance = torch.matmul(
         (normalized_weights.unsqueeze(-1) * centered_inputs).transpose(-1, -2),
         centered_inputs,

--- a/cheetah/utils/statistics.py
+++ b/cheetah/utils/statistics.py
@@ -48,6 +48,20 @@ def unbiased_weighted_variance(
     return variance
 
 
+def unbiased_weighted_std(
+    input: torch.Tensor, weights: torch.Tensor, dim: int = None
+) -> torch.Tensor:
+    """
+    Compute the unbiased weighted standard deviation of a tensor.
+
+    :param input: Input tensor.
+    :param weights: Weights tensor.
+    :param dim: Dimension along which to compute the standard deviation.
+    :return: Unbiased weighted standard deviation.
+    """
+    return torch.sqrt(unbiased_weighted_variance(input, weights, dim=dim))
+
+
 def unbiased_weighted_covariance_matrix(
     inputs: torch.Tensor, weights: torch.Tensor, dim: int = -2
 ) -> torch.Tensor:
@@ -81,17 +95,3 @@ def unbiased_weighted_covariance_matrix(
     ) / correction.unsqueeze(-1)
 
     return cov
-
-
-def unbiased_weighted_std(
-    input: torch.Tensor, weights: torch.Tensor, dim: int = None
-) -> torch.Tensor:
-    """
-    Compute the unbiased weighted standard deviation of a tensor.
-
-    :param input: Input tensor.
-    :param weights: Weights tensor.
-    :param dim: Dimension along which to compute the standard deviation.
-    :return: Unbiased weighted standard deviation.
-    """
-    return torch.sqrt(unbiased_weighted_variance(input, weights, dim=dim))

--- a/cheetah/utils/statistics.py
+++ b/cheetah/utils/statistics.py
@@ -76,9 +76,7 @@ def unbiased_weighted_covariance_matrix(
     normalized_weights = weights / weights.unsqueeze(-1).sum(dim)
     weighted_means = torch.sum(inputs * normalized_weights.unsqueeze(-1), dim)
     centered_inputs = inputs - weighted_means.unsqueeze(dim)
-    correction_factor = 1 - (
-        torch.sum(normalized_weights**2) / weights.unsqueeze(-1).sum(dim)
-    )
+    correction_factor = 1 - torch.sum(normalized_weights**2)
     covariance = torch.matmul(
         (normalized_weights.unsqueeze(-1) * centered_inputs).transpose(-1, -2),
         centered_inputs,

--- a/cheetah/utils/statistics.py
+++ b/cheetah/utils/statistics.py
@@ -73,22 +73,12 @@ def unbiased_weighted_covariance_matrix(
     :param dim: Dimension along which to compute the covariance.
     :return: Unbiased weighted covariance matrix.
     """
-    unsqueezed_weights = weights.unsqueeze(-1)  # (..., sample_size, 1)
-    sum_of_weights = torch.sum(unsqueezed_weights, dim=dim, keepdim=True)
-    normalized_weights = unsqueezed_weights / sum_of_weights  # (..., sample_size, 1)
-
-    weighted_means = torch.sum(
-        inputs * normalized_weights, dim=dim, keepdim=True
-    )  # (..., 1, n_features)
-
-    centered_inputs = inputs - weighted_means  # (..., sample_size, n_features)
-
-    correction_factor = 1 - (
-        torch.sum(normalized_weights**2, dim=dim) / sum_of_weights.squeeze(dim)
-    )
-
+    normalized_weights = weights / torch.sum(weights)
+    weighted_means = torch.sum(inputs * normalized_weights.unsqueeze(-1), dim)
+    centered_inputs = inputs - weighted_means.unsqueeze(dim)
+    correction_factor = 1 - (torch.sum(normalized_weights**2) / torch.sum(weights))
     covariance = torch.matmul(
-        (normalized_weights * centered_inputs).transpose(-1, -2), centered_inputs
+        (normalized_weights.unsqueeze(-1) * centered_inputs).transpose(-1, -2),
+        centered_inputs,
     ) / correction_factor.unsqueeze(-1)
-
     return covariance

--- a/cheetah/utils/statistics.py
+++ b/cheetah/utils/statistics.py
@@ -73,17 +73,15 @@ def unbiased_weighted_covariance_matrix(
     :return: Unbiased weighted covariance matrix.
     """
     normalized_weights = weights / weights.sum(dim=-1, keepdim=True)
-    unsqueezed_weights = normalized_weights.unsqueeze(-1)
-    correction_factor = 1 - torch.sum(unsqueezed_weights**2, dim=-2, keepdim=True)
+    correction_factor = 1 - torch.sum(normalized_weights**2, dim=-1)
 
-    weighted_means = torch.sum(inputs * unsqueezed_weights, dim=-2, keepdim=True)
+    weighted_means = torch.sum(
+        inputs * normalized_weights.unsqueeze(-1), dim=-2, keepdim=True
+    )
     centered_inputs = inputs - weighted_means
 
-    covariance = (
-        torch.matmul(
-            (unsqueezed_weights * centered_inputs).transpose(-1, -2),
-            centered_inputs,
-        )
-        / correction_factor
-    )
+    covariance = torch.matmul(
+        (normalized_weights.unsqueeze(-1) * centered_inputs).transpose(-1, -2),
+        centered_inputs,
+    ) / correction_factor.unsqueeze(-1).unsqueeze(-1)
     return covariance

--- a/tests/test_compare_beam_type.py
+++ b/tests/test_compare_beam_type.py
@@ -22,7 +22,7 @@ def test_from_twiss():
     )
     particle_beam = cheetah.ParticleBeam.from_twiss(
         num_particles=torch.tensor(
-            [10_000_000]
+            10_000_000
         ),  # Large number of particles reduces noise
         beta_x=torch.tensor(5.91253676811640894),
         alpha_x=torch.tensor(3.55631307633660354),

--- a/tests/test_compare_beam_type.py
+++ b/tests/test_compare_beam_type.py
@@ -21,9 +21,7 @@ def test_from_twiss():
         energy=torch.tensor(6e6),
     )
     particle_beam = cheetah.ParticleBeam.from_twiss(
-        num_particles=torch.tensor(
-            10_000_000
-        ),  # Large number of particles reduces noise
+        num_particles=10_000_000,  # Large number of particles reduces noise
         beta_x=torch.tensor(5.91253676811640894),
         alpha_x=torch.tensor(3.55631307633660354),
         emittance_x=torch.tensor(3.494768647122823e-09),

--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -50,9 +50,7 @@ def test_dipole_vectorized_execution(DipoleType):
     Test that a dipole with vector dimensions behaves as expected.
     """
     incoming = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(100),
-        energy=torch.tensor(1e9),
-        mu_x=torch.tensor(1e-5),
+        num_particles=100, energy=torch.tensor(1e9), mu_x=torch.tensor(1e-5)
     )
 
     # Test vectorisation to generate 3 beam lines

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -27,9 +27,7 @@ def test_diverging_particle_beam():
     """
     drift = cheetah.Drift(length=torch.tensor(1.0))
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(1_000),
-        sigma_px=torch.tensor(2e-4),
-        sigma_py=torch.tensor(2e-4),
+        num_particles=1_000, sigma_px=torch.tensor(2e-4), sigma_py=torch.tensor(2e-4)
     )
     outgoing_beam = drift.track(incoming_beam)
 

--- a/tests/test_parameter_beam.py
+++ b/tests/test_parameter_beam.py
@@ -170,19 +170,17 @@ def test_conversion_to_and_from_particle_beam():
         reconstructed_parameter_beam.sigma_py,
         rtol=1e-3,
     )
-    # TODO: Fix after #332 has been clarified
-    # assert torch.isclose(
-    #     original_parameter_beam.mu_tau, reconstructed_parameter_beam.mu_tau, atol=1e-6
-    # )
+    assert torch.isclose(
+        original_parameter_beam.mu_tau, reconstructed_parameter_beam.mu_tau, atol=1e-6
+    )
     assert torch.isclose(
         original_parameter_beam.sigma_tau,
         reconstructed_parameter_beam.sigma_tau,
         rtol=1e-3,
     )
-    # TODO: Fix after #332 has been clarified
-    # assert torch.isclose(
-    #     original_parameter_beam.mu_p, reconstructed_parameter_beam.mu_p, atol=1e-6
-    # )
+    assert torch.isclose(
+        original_parameter_beam.mu_p, reconstructed_parameter_beam.mu_p, atol=1e-6
+    )
     assert torch.isclose(
         original_parameter_beam.sigma_p, reconstructed_parameter_beam.sigma_p, rtol=1e-3
     )

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -356,10 +356,10 @@ def test_random_subsample_energy_distance_better_than_gaussian(device: torch.dev
         )
 
 
-def test_batched_conversion_to_and_from_parameter_beam():
+def test_vectorized_conversion_to_and_from_parameter_beam():
     """
-    Test that converting a batched `ParticleBeam` to a `ParameterBeam` and back
-    works correctly.
+    Test that converting a vectorised `ParticleBeam` to a `ParameterBeam` and back works
+    correctly.
     """
     num_particles = 10_000_000
     beam = cheetah.ParticleBeam.from_parameters(

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -362,14 +362,14 @@ def test_vectorized_conversion_to_parameter_beam_and_back():
     not throw errors and results in a beam with the same parameters.
     """
     original_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=100_000,
+        num_particles=1_000_000,
         mu_x=torch.tensor((2e-4, 3e-4)),
         sigma_x=torch.tensor((2e-5, 3e-5)),
         energy=torch.tensor((1e7, 2e7)),
     )
 
     roundtrip_converted_beam = original_beam.as_parameter_beam().as_particle_beam(
-        num_particles=100_000
+        num_particles=1_000_000
     )
 
     assert isinstance(roundtrip_converted_beam, cheetah.ParticleBeam)

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -396,7 +396,7 @@ def test_vectorized_conversion_to_parameter_beam_and_back():
         original_beam.mu_tau, roundtrip_converted_beam.mu_tau, rtol=1e-3, atol=1e-6
     )
     assert torch.allclose(
-        original_beam.mu_p, roundtrip_converted_beam.mu_p, rtol=1e-3, atol=1e-6
+        original_beam.mu_p, roundtrip_converted_beam.mu_p, rtol=1e-3, atol=1e-5
     )
     assert torch.allclose(
         original_beam.sigma_x, roundtrip_converted_beam.sigma_x, rtol=1e-3

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -12,7 +12,7 @@ def test_create_from_parameters():
     Test that a `ParticleBeam` created from parameters actually has those parameters.
     """
     beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(1_000_000),
+        num_particles=1_000_000,
         mu_x=torch.tensor(1e-5),
         mu_px=torch.tensor(1e-7),
         mu_y=torch.tensor(2e-5),
@@ -89,7 +89,7 @@ def test_from_twiss_to_twiss():
     parameters.
     """
     beam = cheetah.ParticleBeam.from_twiss(
-        num_particles=torch.tensor(10_000_000),
+        num_particles=10_000_000,
         beta_x=torch.tensor(5.91253676811640894),
         alpha_x=torch.tensor(3.55631307633660354),
         emittance_x=torch.tensor(3.494768647122823e-09),
@@ -125,7 +125,7 @@ def test_generate_uniform_ellipsoid_vectorized():
     energy = torch.tensor([1e7, 2e7])
     total_charge = torch.tensor([1e-9, 3e-9])
 
-    num_particles = torch.tensor(1_000_000)
+    num_particles = 1_000_000
     beam = cheetah.ParticleBeam.uniform_3d_ellipsoid(
         num_particles=num_particles,
         radius_x=radius_x,

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -368,13 +368,58 @@ def test_vectorized_conversion_to_parameter_beam_and_back():
         energy=torch.tensor((1e7, 2e7)),
     )
 
+    # Vectorise survival probabilities make make them slightly different
+    original_beam.survival_probabilities = original_beam.survival_probabilities.repeat(
+        3, 1, 1
+    )
+    original_beam.survival_probabilities[0, 0, : int(1_000_000 / 3)] = 0.3
+    original_beam.survival_probabilities[1, 0, : int(1_000_000 / 3)] = 0.6
+
     roundtrip_converted_beam = original_beam.as_parameter_beam().as_particle_beam(
         num_particles=1_000_000
     )
 
     assert isinstance(roundtrip_converted_beam, cheetah.ParticleBeam)
     assert torch.allclose(
+        original_beam.mu_x, roundtrip_converted_beam.mu_x, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
+        original_beam.mu_px, roundtrip_converted_beam.mu_px, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
+        original_beam.mu_y, roundtrip_converted_beam.mu_y, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
+        original_beam.mu_py, roundtrip_converted_beam.mu_py, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
+        original_beam.mu_tau, roundtrip_converted_beam.mu_tau, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
+        original_beam.mu_p, roundtrip_converted_beam.mu_p, rtol=1e-3, atol=1e-6
+    )
+    assert torch.allclose(
         original_beam.sigma_x, roundtrip_converted_beam.sigma_x, rtol=1e-3
     )
-    assert torch.allclose(original_beam.mu_x, roundtrip_converted_beam.mu_x, rtol=1e-3)
-    assert torch.allclose(original_beam.energy, roundtrip_converted_beam.energy)
+    assert torch.allclose(
+        original_beam.sigma_px, roundtrip_converted_beam.sigma_px, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.sigma_y, roundtrip_converted_beam.sigma_y, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.sigma_py, roundtrip_converted_beam.sigma_py, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.sigma_tau, roundtrip_converted_beam.sigma_tau, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.sigma_p, roundtrip_converted_beam.sigma_p, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.energy, roundtrip_converted_beam.energy, rtol=1e-3
+    )
+    assert torch.allclose(
+        original_beam.total_charge, roundtrip_converted_beam.total_charge, rtol=1e-3
+    )
+    assert torch.allclose(original_beam.s, roundtrip_converted_beam.s, rtol=1e-3)

--- a/tests/test_quadrupole.py
+++ b/tests/test_quadrupole.py
@@ -83,9 +83,7 @@ def test_tilted_quadrupole_vectorized():
     Test that a quadrupole with a tilt behaves as expected in vectorised mode.
     """
     incoming = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(1_000_000),
-        energy=torch.tensor(1e9),
-        mu_x=torch.tensor(1e-5),
+        num_particles=1_000_000, energy=torch.tensor(1e9), mu_x=torch.tensor(1e-5)
     )
     segment = cheetah.Segment(
         [
@@ -128,9 +126,7 @@ def test_tilted_quadrupole_multiple_vector_dimensions():
     )
 
     incoming = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
-        energy=torch.tensor(1e9),
-        mu_x=torch.tensor(1e-5),
+        num_particles=10_000, energy=torch.tensor(1e9), mu_x=torch.tensor(1e-5)
     )
 
     outgoing = segment(incoming)
@@ -158,9 +154,7 @@ def test_quadrupole_length_multiple_vector_dimensions():
     )
 
     incoming = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
-        energy=torch.tensor(1e9),
-        mu_x=torch.tensor(1e-5),
+        num_particles=10_000, energy=torch.tensor(1e9), mu_x=torch.tensor(1e-5)
     )
 
     outgoing = segment(incoming)

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -33,7 +33,7 @@ def test_cold_uniform_beam_expansion(energy):
     beta = torch.sqrt(1 - 1 / gamma**2)
 
     incoming = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=torch.tensor(100_000),
+        num_particles=100_000,
         total_charge=torch.tensor(1e-8),
         energy=energy,
         radius_x=R0,
@@ -88,7 +88,7 @@ def test_vectorized_cold_uniform_beam_expansion():
     beta = torch.sqrt(1 - 1 / gamma**2)
 
     incoming = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=torch.tensor(100_000),
+        num_particles=100_000,
         total_charge=torch.tensor(1e-8).repeat(3, 2),
         energy=energy,
         radius_x=R0,
@@ -139,7 +139,7 @@ def test_vectorized():
     beta = torch.sqrt(1 - 1 / gamma**2)
 
     incoming = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         total_charge=torch.tensor([[1e-9, 2e-9], [3e-9, 4e-9], [5e-9, 6e-9]]),
         energy=energy.expand([3, 2]),
         radius_x=R0.expand([3, 2]),
@@ -173,9 +173,7 @@ def test_incoming_beam_not_modified():
     Tests that the incoming beam is not modified when calling the track method.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
-        sigma_px=torch.tensor(2e-7),
-        sigma_py=torch.tensor(2e-7),
+        num_particles=10_000, sigma_px=torch.tensor(2e-7), sigma_py=torch.tensor(2e-7)
     )
     # Initial beam properties
     incoming_beam_before = incoming_beam.particles
@@ -213,7 +211,7 @@ def test_gradient_value_backward_ad():
     gamma, _, beta = compute_relativistic_factors(energy, species.mass_eV)
 
     incoming_beam = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=torch.tensor(100_000),
+        num_particles=100_000,
         total_charge=torch.tensor(1e-8),
         energy=energy,
         radius_x=R0,
@@ -277,7 +275,7 @@ def test_gradient_value_forward_ad():
     gamma, _, beta = compute_relativistic_factors(energy, species.mass_eV)
 
     incoming_beam = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=torch.tensor(100_000),
+        num_particles=100_000,
         total_charge=torch.tensor(1e-8),
         energy=energy,
         radius_x=R0,
@@ -389,7 +387,7 @@ def test_space_charge_with_aperture_cutoff():
         ]
     )
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         total_charge=torch.tensor(1e-9),
         mu_x=torch.tensor(5e-5),
         sigma_px=torch.tensor(1e-4),

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -24,7 +24,7 @@ def test_tracking_speed():
     segment.AREABSCR1.is_active = True  # Turn screen on and off
 
     particles = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(int(1e5)),
+        num_particles=int(1e5),
         sigma_x=torch.tensor(175e-6),
         sigma_y=torch.tensor(175e-6),
     )

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -102,7 +102,6 @@ def test_unbiased_weighted_covariance_matrix_elementwise_reduction():
     weights = torch.tensor([0.5, 1.0, 1.0, 0.9, 0.9])
 
     matrix = unbiased_weighted_covariance_matrix(data, weights)
-    # matrix = torch.cov(data.T, aweights=weights)
 
     for i in range(3):
         for j in range(3):

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -25,7 +25,7 @@ def test_unbiased_weighted_variance_with_same_weights():
     data = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
     weights = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0])
 
-    expected_variance = torch.var(data, unbiased=True)
+    expected_variance = torch.var(data)
     computed_variance = unbiased_weighted_variance(data, weights)
 
     assert torch.allclose(computed_variance, expected_variance)
@@ -36,7 +36,7 @@ def test_unbiased_weighted_variance_with_different_weights():
     data = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
     weights = torch.tensor([0.5, 0.5, 0.5, 0, 0])
 
-    expected_variance = torch.var(torch.tensor([1.0, 2.0, 3.0]), unbiased=True)
+    expected_variance = torch.var(torch.tensor([1.0, 2.0, 3.0]))
     computed_variance = unbiased_weighted_variance(data, weights)
 
     assert torch.allclose(computed_variance, expected_variance)
@@ -57,7 +57,7 @@ def test_unbiased_weighted_variance_with_small_numbers():
     data = torch.tensor([1e-10, 2e-10, 3e-10, 4e-10, 5e-10], dtype=torch.float32)
     weights = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0], dtype=torch.float32)
 
-    expected_variance = torch.var(data, unbiased=True)
+    expected_variance = torch.var(data)
     computed_variance = unbiased_weighted_variance(data, weights)
 
     assert torch.allclose(computed_variance, expected_variance)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -99,14 +99,16 @@ def test_unbiased_weighted_covariance_matrix_elementwise_reduction():
 
     series = torch.arange(5.0)
     data = torch.stack([series, series**2, series**3], dim=-1)
-    weights = torch.tensor([0.5, 1.0, 1.0, 0.9, 0.9])
+    weights = torch.tensor([[0.5, 1.0, 1.0, 0.9, 0.9], [0.4, 1.2, 1.4, 0.6, 0.7]])
 
     matrix = unbiased_weighted_covariance_matrix(data, weights)
 
     for i in range(3):
         for j in range(3):
-            covariance = unbiased_weighted_covariance(data[:, i], data[:, j], weights)
-            assert torch.allclose(matrix[i, j], covariance)
+            covariance = unbiased_weighted_covariance(
+                data[:, i], data[:, j], weights, dim=-1
+            )
+            assert torch.allclose(matrix[:, i, j], covariance)
 
 
 def test_unbiased_weighted_covariance_matrix_torch():

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -96,7 +96,6 @@ def test_unbiased_weighted_covariance_matrix_elementwise_reduction():
     Test that the unbiased weighted covariance matrix agrees with the covariance if
     calculated elementwise.
     """
-
     series = torch.arange(5.0)
     data = torch.stack([series, series**2, series**3], dim=-1)
     weights = torch.tensor([[0.5, 1.0, 1.0, 0.9, 0.9], [0.4, 1.2, 1.4, 0.6, 0.7]])
@@ -116,7 +115,6 @@ def test_unbiased_weighted_covariance_matrix_torch():
     Test that the unbiased weighted covariance matrix is equal to the result computed
     by torch for the unvectorized case.
     """
-
     series = torch.arange(5.0)
     data = torch.stack([series, series**2, series**3], dim=-1)
     weights = torch.tensor([0.5, 1.0, 1.0, 0.9, 0.9])

--- a/tests/test_transverse_deflecting_cavity.py
+++ b/tests/test_transverse_deflecting_cavity.py
@@ -45,7 +45,7 @@ def test_transverse_deflecting_cavity_energy_length_vectorization():
     correct shape, when the input beam's energy and the TDC's length are vectorised.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         sigma_px=torch.tensor(2e-7),
         sigma_py=torch.tensor(2e-7),
         energy=torch.tensor([50e6, 60e6]),
@@ -69,7 +69,7 @@ def test_transverse_deflecting_cavity_energy_phase_vectorization():
     correct shape, when the input beam's energy and the TDC's phase are vectorised.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         sigma_px=torch.tensor(2e-7),
         sigma_py=torch.tensor(2e-7),
         energy=torch.tensor([50e6, 60e6]),
@@ -93,7 +93,7 @@ def test_transverse_deflecting_cavity_energy_frequency_vectorization():
     correct shape, when the input beam's energy and the TDC's frequency are vectorised.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         sigma_px=torch.tensor(2e-7),
         sigma_py=torch.tensor(2e-7),
         energy=torch.tensor([50e6, 60e6]),
@@ -117,7 +117,7 @@ def test_transverse_deflecting_cavity_all_parameters_vectorization():
     correct shape, when all parameters are vectorised.
     """
     incoming_beam = cheetah.ParticleBeam.from_parameters(
-        num_particles=torch.tensor(10_000),
+        num_particles=10_000,
         sigma_px=torch.tensor(2e-7),
         sigma_py=torch.tensor(2e-7),
         energy=torch.tensor([50e6, 60e6]),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Rework the covariance computation in `ParticleBeam.as_parameter_beam` to fix an issue that caused the covariance to be computed incorrectly for vectorised beams.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

Closes #470.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
