### PR TITLE
Adds key-val lookups in context to rpn and infix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add support for elements (especially `Drift`) with negative length (see #480) (@Hespe)
 - Warnings are now available in the top-level namespace so that they can be referenced as e.g. `cheetah.PhysicsWarning` to shorten `filterwarnigns` code. (see #497) (@jank324)
+- Allows use of previously defined element properties in lattice expressions (ie, referencing the length of a previous element) (see #501) (@amylizzle)
 
 ### 🐛 Bug fixes
 

--- a/cheetah/converters/utils/infix.py
+++ b/cheetah/converters/utils/infix.py
@@ -149,13 +149,13 @@ def _tokenize_expression(expression: str, context: dict) -> list[str]:
         if char.isspace() or char in "+-*/^()[]":
             if current_token:
                 if char == "]" and current_key is not None:
-                    # this will throw an index error if current key is invalid
+                    # This will throw an index error if current key is invalid
                     tokens.append(context[current_token][current_key])
                     current_token = ""
                     current_key = None
                     continue
                 if char == "[" and current_token in context:
-                    # we're doing a var[key] lookup, start reading the key
+                    # We're doing a var[key] lookup, start reading the key
                     current_key = ""
                     continue
 

--- a/cheetah/converters/utils/infix.py
+++ b/cheetah/converters/utils/infix.py
@@ -143,16 +143,22 @@ def _tokenize_expression(expression: str, context: dict) -> list[str]:
     """
     tokens = []
     current_token = ""
+    current_key = None
+
     for char in expression:
-        if char.isspace():
+        if char.isspace() or char in "+-*/^()[]":
             if current_token:
-                if current_token in context:
-                    tokens.append(context[current_token])
-                else:
-                    tokens.append(current_token)
-                current_token = ""
-        elif char in "+-*/^()":
-            if current_token:
+                if char == "]" and current_key is not None:
+                    # this will throw an index error if current key is invalid
+                    tokens.append(context[current_token][current_key])
+                    current_token = ""
+                    current_key = None
+                    continue
+                if char == "[" and current_token in context:
+                    # we're doing a var[key] lookup, start reading the key
+                    current_key = ""
+                    continue
+
                 # Workaround for conflicts between function and var names (i.e. abs and
                 # abs())
                 if char != "(" and current_token in context:
@@ -160,9 +166,15 @@ def _tokenize_expression(expression: str, context: dict) -> list[str]:
                 else:
                     tokens.append(current_token)
                 current_token = ""
-            tokens.append(char)
+            if not char.isspace():
+                tokens.append(char)
         else:
-            current_token += char
+            if current_key is not None:
+                current_key += char
+            else:
+                current_token += char
+
+    # Handle the last token if it exists
     if current_token:
         if current_token in context:
             tokens.append(context[current_token])

--- a/cheetah/converters/utils/rpn.py
+++ b/cheetah/converters/utils/rpn.py
@@ -109,6 +109,19 @@ def evaluate_expression(expression: str, context: dict | None = None) -> Any:
                 except ValueError:
                     if token in context:
                         number = context[token]
+                    elif "[" in token and token[-1] == "]":
+                        # nested lookup var[key]
+                        val, key = token.split("[")
+
+                        key = key[:-1]  # trim the ]
+                        if val in context and key in context[val]:
+                            number = context[val][key]
+                        else:
+                            raise SyntaxError(
+                                f"Invalid expression: {expression} - {token} is"
+                                + " not a number or a variable"
+                            )
+
                     else:
                         raise SyntaxError(
                             f"Invalid expression: {expression} - {token} is"

--- a/cheetah/converters/utils/rpn.py
+++ b/cheetah/converters/utils/rpn.py
@@ -110,10 +110,10 @@ def evaluate_expression(expression: str, context: dict | None = None) -> Any:
                     if token in context:
                         number = context[token]
                     elif "[" in token and token[-1] == "]":
-                        # nested lookup var[key]
+                        # Nested lookup var[key]
                         val, key = token.split("[")
 
-                        key = key[:-1]  # trim the ]
+                        key = key[:-1]  # Trim the ]
                         if val in context and key in context[val]:
                             number = context[val][key]
                         else:

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -127,3 +127,13 @@ def test_infix_error_handling_2():
 
     with pytest.raises(SyntaxError):
         infix.evaluate_expression(expression)
+
+
+def test_infix_nested_var_lookup():
+    """
+    Test that an infix expression with nested variable lookups is correctly evaluated.
+    """
+    expression = "a - b[test]"
+    context = {"a": 10, "b": {"beep": 10, "boop": 100, "test": 5}, "test": 3}
+
+    assert infix.evaluate_expression(expression, context) == 5

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -67,3 +67,13 @@ def test_nested_rpn_expression_with_context():
     expression = "10 2 * pi 4 * +"  # 20 + 12 = 32
 
     assert rpn.evaluate_expression(expression, context) == 32
+
+
+def test_rpn_nested_var_lookup():
+    """
+    Test that an RPN expression with nested variable lookups is correctly evaluated.
+    """
+    expression = "a b[test] -"
+    context = {"a": 10, "b": {"beep": 10, "boop": 100, "test": 5}, "test": 3}
+
+    assert rpn.evaluate_expression(expression, context) == 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adds the ability to reference vars defined on previous elements in the lattice to RPN and infix expression types.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

Required by #498

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [x] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
