### PR TITLE
Fix sign of z_f related to R56 in dipole.py

### DIFF
--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -349,7 +349,10 @@ class Dipole(Element):
         z_f = (
             z
             + (beta * self.length.unsqueeze(-1) / beta0.unsqueeze(-1))
-            - ((1 + pz) * Lp / px_norm)
+            + (
+                (1 + pz) * Lp / px_norm
+            )  # In this line, sign should be + since head-tail convention
+            # is different compared to BmadX. Confirmed with elegant simulaton.
         )
 
         return x_f, px_f, y_f, py, z_f, pz


### PR DESCRIPTION
## Description

Fix a sign of z_f in dipole magnet, which is related to R56

## Motivation and Context

As I reported the issue previously with #523, when I performed the benchmarking simulations using Cheetah and elegant, I found that the bunch length evolution after the bunch compressor is different compared to the elegant simulation. I noticed in dipole.py that z_f (updated longitudinal coordinate) in line 352 has - sign regarding R56 term, which is still following the Bmad-X convention. 

Since the head-tail convention in Cheetah simulation is same as the elegant (and flipped to Bmad-X), I would like to propose a change of the sign of it for bunch length calculation.

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!-- - [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
