### PR TITLE
Shorten `repr` of `Segment`s with many elements

### DIFF
--- a/cheetah/accelerator/aperture.py
+++ b/cheetah/accelerator/aperture.py
@@ -138,12 +138,3 @@ class Aperture(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["x_max", "y_max", "shape", "is_active"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(x_max={repr(self.x_max)}, "
-            + f"y_max={repr(self.y_max)}, "
-            + f"shape={repr(self.shape)}, "
-            + f"is_active={repr(self.is_active)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/bpm.py
+++ b/cheetah/accelerator/bpm.py
@@ -74,6 +74,3 @@ class BPM(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["is_active"]
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(name={repr(self.name)})"

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -345,12 +345,3 @@ class Cavity(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "voltage", "phase", "frequency"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"voltage={repr(self.voltage)}, "
-            + f"phase={repr(self.phase)}, "
-            + f"frequency={repr(self.frequency)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -107,14 +107,6 @@ class CustomTransferMap(Element):
     def is_skippable(self) -> bool:
         return True
 
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}("
-            + f"predefined_transfer_map={repr(self.predefined_transfer_map)}, "
-            + f"length={repr(self.length)}, "
-            + f"name={repr(self.name)})"
-        )
-
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "predefined_transfer_map"]

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -615,21 +615,3 @@ class Dipole(Element):
             "fringe_type",
             "tracking_method",
         ]
-
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"k1={repr(self.k1)}, "
-            + f"dipole_e1={repr(self.dipole_e1)},"
-            + f"dipole_e2={repr(self.dipole_e2)},"
-            + f"tilt={repr(self.tilt)},"
-            + f"gap={repr(self.gap)},"
-            + f"gap_exit={repr(self.gap_exit)},"
-            + f"fringe_integral={repr(self.fringe_integral)},"
-            + f"fringe_integral_exit={repr(self.fringe_integral_exit)},"
-            + f"fringe_at={repr(self.fringe_at)},"
-            + f"fringe_type={repr(self.fringe_type)},"
-            + f"tracking_method={repr(self.tracking_method)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/dipole.py
+++ b/cheetah/accelerator/dipole.py
@@ -613,5 +613,4 @@ class Dipole(Element):
             "fringe_integral_exit",
             "fringe_at",
             "fringe_type",
-            "tracking_method",
         ]

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -204,10 +204,3 @@ class Drift(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "tracking_method"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"tracking_method={repr(self.tracking_method)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -203,4 +203,4 @@ class Drift(Element):
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "tracking_method"]
+        return super().defining_features + ["length"]

--- a/cheetah/accelerator/element.py
+++ b/cheetah/accelerator/element.py
@@ -283,7 +283,11 @@ class Element(ABC, nn.Module):
         NOTE: When overriding this property, make sure to call the super method and
         extend the list it returns.
         """
-        return ["name"]
+        return (
+            ["name"]
+            if len(self.supported_tracking_methods) == 1
+            else ["name", "tracking_method"]
+        )
 
     @property
     def defining_tensors(self) -> list[str]:

--- a/cheetah/accelerator/element.py
+++ b/cheetah/accelerator/element.py
@@ -431,4 +431,8 @@ class Element(ABC, nn.Module):
         return mesh, output_transform
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(name={repr(self.name)})"
+        feature_list = [
+            f"{feature}={repr(getattr(self, feature))}"
+            for feature in self.defining_features
+        ]
+        return f"{self.__class__.__name__}({", ".join(feature_list)})"

--- a/cheetah/accelerator/horizontal_corrector.py
+++ b/cheetah/accelerator/horizontal_corrector.py
@@ -97,10 +97,3 @@ class HorizontalCorrector(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "angle"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/marker.py
+++ b/cheetah/accelerator/marker.py
@@ -50,10 +50,3 @@ class Marker(Element):
         # TODO: Implement a better visualisation for markers. At the moment they are
         # invisible.
         return ax
-
-    @property
-    def defining_features(self) -> list[str]:
-        return super().defining_features
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(name={repr(self.name)})"

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -342,16 +342,6 @@ class Quadrupole(Element):
             "k1",
             "misalignment",
             "tilt",
+            "num_steps",
             "tracking_method",
         ]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"k1={repr(self.k1)}, "
-            + f"misalignment={repr(self.misalignment)}, "
-            + f"tilt={repr(self.tilt)}, "
-            + f"num_steps={repr(self.num_steps)}, "
-            + f"tracking_method={repr(self.tracking_method)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/quadrupole.py
+++ b/cheetah/accelerator/quadrupole.py
@@ -343,5 +343,4 @@ class Quadrupole(Element):
             "misalignment",
             "tilt",
             "num_steps",
-            "tracking_method",
         ]

--- a/cheetah/accelerator/rbend.py
+++ b/cheetah/accelerator/rbend.py
@@ -131,24 +131,6 @@ class RBend(Dipole):
     def rbend_e2(self, value):
         self.dipole_e2 = value + self.angle / 2
 
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"k1={repr(self.k1)}, "
-            + f"rbend_e1={repr(self.rbend_e1)},"
-            + f"rbend_e2={repr(self.rbend_e2)},"
-            + f"tilt={repr(self.tilt)},"
-            + f"gap={repr(self.gap)},"
-            + f"gap_exit={repr(self.gap_exit)},"
-            + f"fringe_integral={repr(self.fringe_integral)},"
-            + f"fringe_integral_exit={repr(self.fringe_integral_exit)},"
-            + f"fringe_at={repr(self.fringe_at)},"
-            + f"fringe_type={repr(self.fringe_type)},"
-            + f"tracking_method={repr(self.tracking_method)}, "
-            + f"name={repr(self.name)})"
-        )
-
     @property
     def defining_features(self):
         dipole_features = super().defining_features

--- a/cheetah/accelerator/screen.py
+++ b/cheetah/accelerator/screen.py
@@ -357,15 +357,3 @@ class Screen(Element):
             "kde_bandwidth",
             "is_active",
         ]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(resolution={repr(self.resolution)}, "
-            + f"pixel_size={repr(self.pixel_size)}, "
-            + f"binning={repr(self.binning)}, "
-            + f"misalignment={repr(self.misalignment)}, "
-            + f"method={repr(self.method)}, "
-            + f"kde_bandwidth={repr(self.kde_bandwidth)}, "
-            + f"is_active={repr(self.is_active)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -877,7 +877,19 @@ class Segment(Element):
         return super().defining_features + ["elements"]
 
     def __repr__(self) -> str:
+        num_elements = len(self.elements)
+        if num_elements <= 5:  # TODO Discuss a reasonable threshold
+            elements_repr = repr(self.elements)
+        else:
+            repr_list = [
+                f"({i}): {repr(self.elements[i])}"
+                for i in [0, 1, num_elements - 2, num_elements - 1]
+            ]
+            repr_list.insert(2, " ⋮")
+
+            elements_repr = f"ModuleList(\n  {'\n  '.join(repr_list)}\n)"
+
         return (
-            f"{self.__class__.__name__}(elements={repr(self.elements)}, "
+            f"{self.__class__.__name__}(elements={elements_repr}, "
             + f"name={repr(self.name)})"
         )

--- a/cheetah/accelerator/sextupole.py
+++ b/cheetah/accelerator/sextupole.py
@@ -146,5 +146,4 @@ class Sextupole(Element):
             "k2",
             "misalignment",
             "tilt",
-            "tracking_method",
         ]

--- a/cheetah/accelerator/sextupole.py
+++ b/cheetah/accelerator/sextupole.py
@@ -141,13 +141,10 @@ class Sextupole(Element):
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "k2", "misalignment", "tilt"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            f"k2={repr(self.k2)}, "
-            f"misalignment={repr(self.misalignment)}, "
-            f"tilt={repr(self.tilt)}, "
-            f"name={repr(self.name)})"
-        )
+        return super().defining_features + [
+            "length",
+            "k2",
+            "misalignment",
+            "tilt",
+            "tracking_method",
+        ]

--- a/cheetah/accelerator/solenoid.py
+++ b/cheetah/accelerator/solenoid.py
@@ -153,11 +153,3 @@ class Solenoid(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "k", "misalignment"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"k={repr(self.k)}, "
-            + f"misalignment={repr(self.misalignment)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -692,13 +692,3 @@ class SpaceChargeKick(Element):
             "grid_extent_y",
             "grid_extent_tau",
         ]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(effect_length={repr(self.effect_length)}, "
-            + f"grid_shape={repr(self.grid_shape)}, "
-            + f"grid_extent_x={repr(self.grid_extent_x)}, "
-            + f"grid_extent_y={repr(self.grid_extent_y)}, "
-            + f"grid_extent_tau={repr(self.grid_extent_tau)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -236,5 +236,4 @@ class TransverseDeflectingCavity(Element):
             "misalignment",
             "tilt",
             "num_steps",
-            "tracking_method",
         ]

--- a/cheetah/accelerator/transverse_deflecting_cavity.py
+++ b/cheetah/accelerator/transverse_deflecting_cavity.py
@@ -238,16 +238,3 @@ class TransverseDeflectingCavity(Element):
             "num_steps",
             "tracking_method",
         ]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"voltage={repr(self.voltage)}, "
-            + f"phase={repr(self.phase)}, "
-            + f"frequency={repr(self.frequency)}, "
-            + f"misalignment={repr(self.misalignment)}, "
-            + f"tilt={repr(self.tilt)}, "
-            + f"num_steps={repr(self.num_steps)}, "
-            + f"tracking_method={repr(self.tracking_method)}, "
-            + f"name={repr(self.name)})"
-        )

--- a/cheetah/accelerator/undulator.py
+++ b/cheetah/accelerator/undulator.py
@@ -81,11 +81,4 @@ class Undulator(Element):
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"is_active={repr(self.is_active)}, "
-            + f"name={repr(self.name)})"
-        )
+        return super().defining_features + ["length", "is_active"]

--- a/cheetah/accelerator/vertical_corrector.py
+++ b/cheetah/accelerator/vertical_corrector.py
@@ -97,10 +97,3 @@ class VerticalCorrector(Element):
     @property
     def defining_features(self) -> list[str]:
         return super().defining_features + ["length", "angle"]
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(length={repr(self.length)}, "
-            + f"angle={repr(self.angle)}, "
-            + f"name={repr(self.name)})"
-        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

For large lattices, generating the `repr` of `Segment` can take more than a second. This is especially irritating when debugging since the the debugger will struggle to generate the variable list in that case.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
 - Closes #237

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
