### PR TITLE
516 second order customtransfermap

### DIFF
--- a/cheetah/accelerator/custom_transfer_map.py
+++ b/cheetah/accelerator/custom_transfer_map.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import matplotlib.pyplot as plt
 import torch
 from matplotlib.patches import Rectangle
@@ -21,12 +23,13 @@ class CustomTransferMap(Element):
         access the element in a segment.
     """
 
-    supported_tracking_methods = ["linear"]
+    supported_tracking_methods = ["linear", "second_order"]
 
     def __init__(
         self,
         predefined_transfer_map: torch.Tensor,
         length: torch.Tensor | None = None,
+        tracking_method: Literal["linear", "second_order"] = "linear",
         name: torch.Tensor | None = None,
         sanitize_name: bool = False,
         device: torch.device | None = None,
@@ -38,18 +41,27 @@ class CustomTransferMap(Element):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__(name=name, sanitize_name=sanitize_name, **factory_kwargs)
 
+        self.tracking_method = tracking_method
         if length is not None:
             self.length = torch.as_tensor(length, **factory_kwargs)
 
-        assert (predefined_transfer_map[..., -1, :-2] == 0.0).all() and (
-            predefined_transfer_map[..., -1, -1] == 1.0
-        ).all(), "The seventh row of the transfer map must be [0, 0, 0, 0, 0, 0, 1]."
+        if self.tracking_method == "second_order":
+            assert predefined_transfer_map.shape[-3:] == (7, 7, 7)
+            assert (
+                (predefined_transfer_map[..., -1, :, :-1] == 0.0).all()
+                and (predefined_transfer_map[..., -1, :-1, -1] == 0.0).all()
+                and (predefined_transfer_map[..., -1, -1, -1] == 1.0).all()
+            ), "The final plane of the output dimension must only contain a single 1."
+        else:
+            assert predefined_transfer_map.shape[-2:] == (7, 7)
+            assert (predefined_transfer_map[..., -1, :-1] == 0.0).all() and (
+                predefined_transfer_map[..., -1, -1] == 1.0
+            ).all(), "The final row of the transfer map must be [0, 0, 0, 0, 0, 0, 1]."
+
         self.register_buffer_or_parameter(
             "predefined_transfer_map",
             torch.as_tensor(predefined_transfer_map, **factory_kwargs),
         )
-
-        assert self.predefined_transfer_map.shape[-2:] == (7, 7)
 
     @classmethod
     def from_merging_elements(
@@ -98,26 +110,70 @@ class CustomTransferMap(Element):
             tm, length=combined_length, device=device, dtype=dtype, name=combined_name
         )
 
+    def track(self, incoming: Beam) -> Beam:
+        """
+        Track particles through the custom transfer map.
+
+        :param incoming: Beam entering the element.
+        :return: Beam exiting the element.
+        """
+        if self.tracking_method == "linear":
+            return super()._track_first_order(incoming)
+        elif self.tracking_method == "second_order":
+            return super()._track_second_order(incoming)
+        else:
+            raise ValueError(
+                f"Invalid tracking method {self.tracking_method}. For element of"
+                f" type {self.__class__.__name__}, supported methods are "
+                f"{self.supported_tracking_methods}."
+            )
+
     def first_order_transfer_map(
         self, energy: torch.Tensor, species: Species
     ) -> torch.Tensor:
-        return self.predefined_transfer_map
+        if self.tracking_method == "linear":
+            return self.predefined_transfer_map
+        else:
+            transfer_map = self.predefined_transfer_map[..., :, 6, :]
+            transfer_map[..., :6, :] += self.predefined_transfer_map[..., :6, :, 6]
+
+            return transfer_map
+
+    def second_order_transfer_map(
+        self, energy: torch.Tensor, species: Species
+    ) -> torch.Tensor:
+        if self.tracking_method == "second_order":
+            return self.predefined_transfer_map
+        else:
+            transfer_map = torch.zeros(
+                (*self.predefined_transfer_map.shape[:-2], 7, 7, 7),
+                device=self.predefined_transfer_map.device,
+                dtype=self.predefined_transfer_map.dtype,
+            )
+            transfer_map[..., :, 6, :] = self.predefined_transfer_map
+
+            return transfer_map
 
     @property
     def is_skippable(self) -> bool:
-        return True
+        return self.tracking_method == "linear"
 
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
             + f"predefined_transfer_map={repr(self.predefined_transfer_map)}, "
             + f"length={repr(self.length)}, "
+            + f"tracking_method={repr(self.tracking_method)}, "
             + f"name={repr(self.name)})"
         )
 
     @property
     def defining_features(self) -> list[str]:
-        return super().defining_features + ["length", "predefined_transfer_map"]
+        return super().defining_features + [
+            "length",
+            "predefined_transfer_map",
+            "tracking_method",
+        ]
 
     def plot(
         self, s: float, vector_idx: tuple | None = None, ax: plt.Axes | None = None

--- a/cheetah/accelerator/drift.py
+++ b/cheetah/accelerator/drift.py
@@ -77,7 +77,7 @@ class Drift(Element):
 
     def track(self, incoming: Beam) -> Beam:
         """
-        Track particles through the dipole element.
+        Track particles through the drift element.
 
         :param incoming: Beam entering the element.
         :return: Beam exiting the element.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,18 @@ ELEMENT_SUBCLASSES_ARGS = {
     cheetah.Aperture: {"inactive": {"is_active": False}, "active": {"is_active": True}},
     cheetah.BPM: {"inactive": {"is_active": False}, "active": {"is_active": True}},
     cheetah.Cavity: {"default": {"length": torch.tensor(1.0)}},
-    cheetah.CustomTransferMap: {"identity": {"predefined_transfer_map": torch.eye(7)}},
+    cheetah.CustomTransferMap: {
+        "linear": {
+            "predefined_transfer_map": torch.eye(7),
+            "tracking_method": "linear",
+        },
+        "second_order": {
+            "predefined_transfer_map": torch.cat(
+                [torch.zeros(7, 7, 6), torch.eye(7).unsqueeze(-1)], dim=-1
+            ),
+            "tracking_method": "second_order",
+        },
+    },
     cheetah.Dipole: {
         "linear": {
             "length": torch.tensor(1.0),

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -102,6 +102,7 @@ def test_particle_beam_tracking_with_device_and_dtype(element, device, dtype):
         isinstance(
             element,
             (
+                cheetah.CustomTransferMap,
                 cheetah.Dipole,
                 cheetah.Drift,
                 cheetah.Quadrupole,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`CustomTransferMap` currently does only support linear tracking. This PR adds support for second-order `CustomTransferMap`s.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - Closes #516 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
