### PR TITLE
535 include dispersion into the twiss parameters calculation and beam initialization using from twiss

### DIFF
--- a/cheetah/particles/parameter_beam.py
+++ b/cheetah/particles/parameter_beam.py
@@ -588,6 +588,22 @@ class ParameterBeam(Beam):
     def cov_taup(self) -> torch.Tensor:
         return self.cov[..., 4, 5]
 
+    @property
+    def cov_xp(self) -> torch.Tensor:
+        return self.cov[..., 0, 5]
+
+    @property
+    def cov_pxp(self) -> torch.Tensor:
+        return self.cov[..., 1, 5]
+
+    @property
+    def cov_yp(self) -> torch.Tensor:
+        return self.cov[..., 2, 5]
+
+    @property
+    def cov_pyp(self) -> torch.Tensor:
+        return self.cov[..., 3, 5]
+
     def clone(self) -> "ParameterBeam":
         return self.__class__(
             mu=self.mu.clone(),

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -135,6 +135,10 @@ class ParticleBeam(Beam):
         cov_xpx: torch.Tensor | None = None,
         cov_ypy: torch.Tensor | None = None,
         cov_taup: torch.Tensor | None = None,
+        cov_xp: torch.Tensor | None = None,
+        cov_pxp: torch.Tensor | None = None,
+        cov_yp: torch.Tensor | None = None,
+        cov_pyp: torch.Tensor | None = None,
         energy: torch.Tensor | None = None,
         total_charge: torch.Tensor | None = None,
         s: torch.Tensor | None = None,
@@ -166,6 +170,10 @@ class ParticleBeam(Beam):
         :param cov_xpx: Correlation between x and px.
         :param cov_ypy: Correlation between y and py.
         :param cov_taup: Correlation between s and p.
+        :param cov_xp: Correlation between x and p.
+        :param cov_pxp: Correlation between px and p.
+        :param cov_yp: Correlation between y and p.
+        :param cov_pyp: Correlation between py and p.
         :param energy: Energy of the beam in eV.
         :param total_charge: Total charge of the beam in C.
         :param s: Position along the beamline of the reference particle in meters.
@@ -193,6 +201,10 @@ class ParticleBeam(Beam):
                 cov_xpx,
                 cov_ypy,
                 cov_taup,
+                cov_xp,
+                cov_pxp,
+                cov_yp,
+                cov_pyp,
                 energy,
                 total_charge,
                 s,
@@ -236,6 +248,14 @@ class ParticleBeam(Beam):
         cov_taup = (
             cov_taup if cov_taup is not None else torch.tensor(0.0, **factory_kwargs)
         )
+        cov_xp = cov_xp if cov_xp is not None else torch.tensor(0.0, **factory_kwargs)
+        cov_pxp = (
+            cov_pxp if cov_pxp is not None else torch.tensor(0.0, **factory_kwargs)
+        )
+        cov_yp = cov_yp if cov_yp is not None else torch.tensor(0.0, **factory_kwargs)
+        cov_pyp = (
+            cov_pyp if cov_pyp is not None else torch.tensor(0.0, **factory_kwargs)
+        )
 
         mu_x, mu_px, mu_y, mu_py, mu_tau, mu_p = torch.broadcast_tensors(
             mu_x, mu_px, mu_y, mu_py, mu_tau, mu_p
@@ -252,6 +272,10 @@ class ParticleBeam(Beam):
             sigma_tau,
             sigma_p,
             cov_taup,
+            cov_xp,
+            cov_pxp,
+            cov_yp,
+            cov_pyp,
         ) = torch.broadcast_tensors(
             sigma_x,
             sigma_px,
@@ -262,6 +286,10 @@ class ParticleBeam(Beam):
             sigma_tau,
             sigma_p,
             cov_taup,
+            cov_xp,
+            cov_pxp,
+            cov_yp,
+            cov_pyp,
         )
         cov = torch.zeros(*sigma_x.shape, 6, 6, **factory_kwargs)
         cov[..., 0, 0] = sigma_x**2
@@ -276,6 +304,14 @@ class ParticleBeam(Beam):
         cov[..., 4, 5] = cov_taup
         cov[..., 5, 4] = cov_taup
         cov[..., 5, 5] = sigma_p**2
+        cov[..., 0, 5] = cov_xp
+        cov[..., 5, 0] = cov_xp
+        cov[..., 1, 5] = cov_pxp
+        cov[..., 5, 1] = cov_pxp
+        cov[..., 2, 5] = cov_yp
+        cov[..., 5, 2] = cov_yp
+        cov[..., 3, 5] = cov_pyp
+        cov[..., 5, 3] = cov_pyp
 
         return cls.from_distribution(
             mu=mean,
@@ -376,6 +412,10 @@ class ParticleBeam(Beam):
         beta_y: torch.Tensor | None = None,
         alpha_y: torch.Tensor | None = None,
         emittance_y: torch.Tensor | None = None,
+        disp_x: torch.Tensor | None = None,
+        disp_px: torch.Tensor | None = None,
+        disp_y: torch.Tensor | None = None,
+        disp_py: torch.Tensor | None = None,
         energy: torch.Tensor | None = None,
         sigma_tau: torch.Tensor | None = None,
         sigma_p: torch.Tensor | None = None,
@@ -395,6 +435,10 @@ class ParticleBeam(Beam):
                 beta_y,
                 alpha_y,
                 emittance_y,
+                disp_x,
+                disp_px,
+                disp_y,
+                disp_py,
                 energy,
                 sigma_tau,
                 sigma_p,
@@ -426,6 +470,14 @@ class ParticleBeam(Beam):
             if emittance_y is not None
             else torch.tensor(7.1971891e-13, **factory_kwargs)
         )
+        disp_x = disp_x if disp_x is not None else torch.tensor(0.0, **factory_kwargs)
+        disp_px = (
+            disp_px if disp_px is not None else torch.tensor(0.0, **factory_kwargs)
+        )
+        disp_y = disp_y if disp_y is not None else torch.tensor(0.0, **factory_kwargs)
+        disp_py = (
+            disp_py if disp_py is not None else torch.tensor(0.0, **factory_kwargs)
+        )
         energy = energy if energy is not None else torch.tensor(1e8, **factory_kwargs)
         sigma_tau = (
             sigma_tau if sigma_tau is not None else torch.tensor(1e-6, **factory_kwargs)
@@ -437,12 +489,21 @@ class ParticleBeam(Beam):
             cov_taup if cov_taup is not None else torch.tensor(0.0, **factory_kwargs)
         )
 
-        sigma_x = torch.sqrt(beta_x * emittance_x)
-        sigma_px = torch.sqrt(emittance_x * (1 + alpha_x**2) / beta_x)
-        sigma_y = torch.sqrt(beta_y * emittance_y)
-        sigma_py = torch.sqrt(emittance_y * (1 + alpha_y**2) / beta_y)
-        cov_xpx = -emittance_x * alpha_x
-        cov_ypy = -emittance_y * alpha_y
+        sigma_x = torch.sqrt(beta_x * emittance_x + disp_x**2 * sigma_p**2)
+        sigma_px = torch.sqrt(
+            emittance_x * (1 + alpha_x**2) / beta_x + disp_px**2 * sigma_p**2
+        )
+        sigma_y = torch.sqrt(beta_y * emittance_y + disp_y**2 * sigma_p**2)
+        sigma_py = torch.sqrt(
+            emittance_y * (1 + alpha_y**2) / beta_y + disp_py**2 * sigma_p**2
+        )
+        cov_xpx = -emittance_x * alpha_x + disp_x * disp_px * sigma_p**2
+        cov_ypy = -emittance_y * alpha_y + disp_y * disp_py * sigma_p**2
+
+        cov_xp = disp_x * sigma_p**2
+        cov_pxp = disp_px * sigma_p**2
+        cov_yp = disp_y * sigma_p**2
+        cov_pyp = disp_py * sigma_p**2
 
         return cls.from_parameters(
             num_particles=num_particles,
@@ -460,6 +521,10 @@ class ParticleBeam(Beam):
             cov_taup=cov_taup,
             cov_xpx=cov_xpx,
             cov_ypy=cov_ypy,
+            cov_xp=cov_xp,
+            cov_pxp=cov_pxp,
+            cov_yp=cov_yp,
+            cov_pyp=cov_pyp,
             total_charge=total_charge,
             s=s,
             species=species,

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -1752,6 +1752,46 @@ class ParticleBeam(Beam):
         )
 
     @property
+    def cov_xp(self) -> torch.Tensor:
+        r"""
+        Returns the covariance between x and p. :math:`\sigma_{x, p}^2`.
+        It is weighted by the survival probability of the particles.
+        """
+        return unbiased_weighted_covariance(
+            self.x, self.p, weights=self.survival_probabilities, dim=-1
+        )
+
+    @property
+    def cov_pxp(self) -> torch.Tensor:
+        r"""
+        Returns the covariance between px and p. :math:`\sigma_{px, p}^2`.
+        It is weighted by the survival probability of the particles.
+        """
+        return unbiased_weighted_covariance(
+            self.px, self.p, weights=self.survival_probabilities, dim=-1
+        )
+
+    @property
+    def cov_yp(self) -> torch.Tensor:
+        r"""
+        Returns the covariance between y and p. :math:`\sigma_{y, p}^2`.
+        It is weighted by the survival probability of the particles.
+        """
+        return unbiased_weighted_covariance(
+            self.y, self.p, weights=self.survival_probabilities, dim=-1
+        )
+
+    @property
+    def cov_pyp(self) -> torch.Tensor:
+        r"""
+        Returns the covariance between py and p. :math:`\sigma_{py, p}^2`.
+        It is weighted by the survival probability of the particles.
+        """
+        return unbiased_weighted_covariance(
+            self.py, self.p, weights=self.survival_probabilities, dim=-1
+        )
+
+    @property
     def energies(self) -> torch.Tensor:
         """Energies of the individual particles."""
         return self.p * self.p0c + self.energy

--- a/tests/test_parameter_beam.py
+++ b/tests/test_parameter_beam.py
@@ -109,6 +109,9 @@ def test_from_twiss_dtype():
         beta_y=torch.tensor(5.91253676811640982),
         alpha_y=torch.tensor(2e-7),
         emittance_y=torch.tensor(3.497810737006068e-09),
+        disp_x=torch.tensor(2e-2),
+        disp_px=torch.tensor(1e-3),
+        sigma_p=torch.tensor(1e-3),
         energy=torch.tensor(6e6),
         dtype=torch.float64,
     )
@@ -119,6 +122,9 @@ def test_from_twiss_dtype():
     assert np.isclose(beam.beta_y.cpu().numpy(), 5.91253676811640982)
     assert np.isclose(beam.alpha_y.cpu().numpy(), 2e-7)
     assert np.isclose(beam.emittance_y.cpu().numpy(), 3.497810737006068e-09)
+    assert np.isclose(beam.disp_x.cpu().numpy(), 2e-2)
+    assert np.isclose(beam.disp_px.cpu().numpy(), 1e-3)
+    assert np.isclose(beam.sigma_p.cpu().numpy(), 1e-3)
     assert np.isclose(beam.energy.cpu().numpy(), 6e6)
 
     assert beam.mu.dtype == torch.float64

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -26,6 +26,10 @@ def test_create_from_parameters():
         cov_xpx=torch.tensor(0.0),
         cov_ypy=torch.tensor(0.0),
         cov_taup=torch.tensor(0.0),
+        cov_xp=torch.tensor(0.0),
+        cov_pxp=torch.tensor(0.0),
+        cov_yp=torch.tensor(0.0),
+        cov_pyp=torch.tensor(0.0),
         energy=torch.tensor(1e7),
         total_charge=torch.tensor(1e-9),
     )
@@ -96,15 +100,19 @@ def test_from_twiss_to_twiss():
         beta_y=torch.tensor(5.91253676811640982),
         alpha_y=torch.tensor(1.0),  # TODO: set realistic value
         emittance_y=torch.tensor(3.497810737006068e-09),
+        disp_x=torch.tensor(2e-2),
+        sigma_p=torch.tensor(1e-3),
         energy=torch.tensor(6e6),
     )
     # rather loose rtol is needed here due to the random sampling of the beam
-    assert np.isclose(beam.beta_x.cpu().numpy(), 5.91253676811640894, rtol=1e-2)
-    assert np.isclose(beam.alpha_x.cpu().numpy(), 3.55631307633660354, rtol=1e-2)
-    assert np.isclose(beam.emittance_x.cpu().numpy(), 3.494768647122823e-09, rtol=1e-2)
-    assert np.isclose(beam.beta_y.cpu().numpy(), 5.91253676811640982, rtol=1e-2)
-    assert np.isclose(beam.alpha_y.cpu().numpy(), 1.0, rtol=1e-2)
-    assert np.isclose(beam.emittance_y.cpu().numpy(), 3.497810737006068e-09, rtol=1e-2)
+    assert np.isclose(beam.beta_x.cpu().numpy(), 5.91253676811640894, rtol=1e-3)
+    assert np.isclose(beam.alpha_x.cpu().numpy(), 3.55631307633660354, rtol=1e-3)
+    assert np.isclose(beam.emittance_x.cpu().numpy(), 3.494768647122823e-09, rtol=1e-3)
+    assert np.isclose(beam.beta_y.cpu().numpy(), 5.91253676811640982, rtol=1e-3)
+    assert np.isclose(beam.alpha_y.cpu().numpy(), 1.0, rtol=1e-3)
+    assert np.isclose(beam.emittance_y.cpu().numpy(), 3.497810737006068e-09, rtol=1e-3)
+    assert np.isclose(beam.sigma_p.cpu().numpy(), 1e-3, rtol=1e-3)
+    assert np.isclose(beam.disp_x.cpu().numpy(), 2e-2, rtol=1e-2)
     assert np.isclose(beam.energy.cpu().numpy(), 6e6)
 
 
@@ -246,7 +254,7 @@ def test_indexing_with_vectorized_incoming_beam():
     incoming = cheetah.ParticleBeam.from_parameters(
         num_particles=1_000,
         sigma_x=torch.tensor(1e-5),
-        energy=torch.rand((5, 2)) * 154e6,
+        energy=(0.5 + torch.rand((5, 2))) * 154e6,
     )
 
     outgoing = quadrupole.track(incoming)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
