### PR TITLE
Ensure inactive `Cavity` do not produce `NaN` in their transfer map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Shorten `__repr__` of `Segment` for large lattices to prevent debugging slowdowns (see #529) (@Hespe)
 - Fix typo saying Bmad in Elegant import method docstring (see #531) (@jank324)
+- Remove division by zero in `Cavity` for off-crest phase (see #549) (@Hespe)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/cavity.py
+++ b/cheetah/accelerator/cavity.py
@@ -84,7 +84,7 @@ class Cavity(Element):
         self, energy: torch.Tensor, species: Species
     ) -> torch.Tensor:
         return torch.where(
-            (self.voltage != 0 and (self.phase / 90) % 2 != 1.0)
+            torch.logical_and(self.voltage != 0, (self.phase / 90) % 2 != 1.0)
             .unsqueeze(-1)
             .unsqueeze(-1),
             self._cavity_rmatrix(energy, species),
@@ -315,7 +315,8 @@ class Cavity(Element):
 
         elif self.cavity_type == "traveling_wave":
             # Reference paper: Rosenzweig and Serafini, PhysRevE, Vol.49, p.1599,(1994)
-            f = Ei / delta_energy * torch.log(1 + (delta_energy / Ei))
+            dE = delta_energy / species.mass_eV
+            f = Ei / dE * torch.log(1 + (dE / Ei))
 
             vector_shape = torch.broadcast_shapes(
                 self.length.shape, f.shape, Ei.shape, Ef.shape
@@ -326,10 +327,10 @@ class Cavity(Element):
             M_body[..., 1, 1] = Ei / Ef
 
             M_f_entry = torch.eye(2, **factory_kwargs).repeat((*vector_shape, 1, 1))
-            M_f_entry[..., 1, 0] = -delta_energy / (2 * self.length * Ei)
+            M_f_entry[..., 1, 0] = -dE / (2 * self.length * Ei)
 
             M_f_exit = torch.eye(2, **factory_kwargs).repeat((*vector_shape, 1, 1))
-            M_f_exit[..., 1, 0] = delta_energy / (2 * self.length * Ef)
+            M_f_exit[..., 1, 0] = dE / (2 * self.length * Ef)
 
             M_combined = M_f_exit @ M_body @ M_f_entry
 

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -37,23 +37,9 @@ def test_assert_ei_greater_zero():
     [
         (torch.tensor(0.0), torch.tensor(-90.0)),
         (torch.tensor(1e6), torch.tensor(0.0)),
-        (torch.tensor([0.0, 1e6]), torch.tensor(-90.0)),
-        (torch.tensor([0.0, 1e6]), torch.tensor(0.0)),
-        (torch.tensor(0.0), torch.tensor([-90.0, 0.0])),
-        (torch.tensor(1e6), torch.tensor([-90.0, 0.0])),
-        (torch.tensor([0.0, 1e6]), torch.tensor([0.0, -90.0])),
-        (torch.tensor([0.0, 1e6]), torch.tensor([-90.0, 0.0])),
+        (torch.tensor([0.0, 1e6]), torch.tensor([[-90.0], [0.0]])),
     ],
-    ids=[
-        "off",
-        "on",
-        "phase-offcrest",
-        "phase-oncrest",
-        "voltage-off",
-        "voltage-on",
-        "mixed-swapped",
-        "mixed-aligned",
-    ],
+    ids=["off", "on", "mixed"],
 )
 @pytest.mark.parametrize("cavity_type", ["standing_wave", "traveling_wave"])
 def test_vectorized_inactive_cavity(cavity_type, voltage, phase):

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -35,12 +35,12 @@ def test_assert_ei_greater_zero():
 @pytest.mark.parametrize(
     ("voltage", "phase"),
     [
-        (torch.tensor([0.0]), torch.tensor([-90.0])),
-        (torch.tensor([1e6]), torch.tensor([0.0])),
-        (torch.tensor([0.0, 1e6]), torch.tensor([-90.0])),
-        (torch.tensor([0.0, 1e6]), torch.tensor([0.0])),
-        (torch.tensor([0.0]), torch.tensor([-90.0, 0.0])),
-        (torch.tensor([1e6]), torch.tensor([-90.0, 0.0])),
+        (torch.tensor(0.0), torch.tensor(-90.0)),
+        (torch.tensor(1e6), torch.tensor(0.0)),
+        (torch.tensor([0.0, 1e6]), torch.tensor(-90.0)),
+        (torch.tensor([0.0, 1e6]), torch.tensor(0.0)),
+        (torch.tensor(0.0), torch.tensor([-90.0, 0.0])),
+        (torch.tensor(1e6), torch.tensor([-90.0, 0.0])),
         (torch.tensor([0.0, 1e6]), torch.tensor([0.0, -90.0])),
         (torch.tensor([0.0, 1e6]), torch.tensor([-90.0, 0.0])),
     ],
@@ -55,7 +55,8 @@ def test_assert_ei_greater_zero():
         "mixed-aligned",
     ],
 )
-def test_vectorized_inactive_cavity(voltage, phase):
+@pytest.mark.parametrize("cavity_type", ["standing_wave", "traveling_wave"])
+def test_vectorized_inactive_cavity(cavity_type, voltage, phase):
     """
     Tests that a vectorised cavity with zero voltage or off-crest phase does not produce
     NaNs and that switched-off cavities can be vectorized with switched-on.
@@ -65,18 +66,14 @@ def test_vectorized_inactive_cavity(voltage, phase):
     of zero voltage or off-crest phase. The latter produced NaNs in the transfer matrix.
     """
     cavity = cheetah.Cavity(
-        length=torch.tensor([3.0441, 3.0441]),
+        cavity_type=cavity_type,
+        length=torch.tensor(3.0441),
         voltage=voltage,
         phase=phase,
-        frequency=torch.tensor([2.8560e09, 2.8560e09]),
-        name="k27_1a",
+        frequency=torch.tensor(2.8560e09),
         dtype=torch.float64,
     )
     incoming = cheetah.ParameterBeam.from_parameters(
-        mu_x=torch.tensor(0.0),
-        mu_px=torch.tensor(0.0),
-        mu_y=torch.tensor(0.0),
-        mu_py=torch.tensor(0.0),
         sigma_x=torch.tensor(4.8492e-06),
         sigma_px=torch.tensor(1.5603e-07),
         sigma_y=torch.tensor(4.1209e-07),

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -36,8 +36,8 @@ def test_assert_ei_greater_zero():
     ("voltage", "phase"),
     [
         (torch.tensor(0.0), torch.tensor([-90.0, 90.0])),
-        (torch.tensor([0.0, 1e6]), torch.tensor([[-90.0], [90.0], [0.0]])),
-        (torch.tensor(1e6), torch.tensor(0.0)),
+        (torch.tensor([0.0, 1e6]), torch.tensor([[-90.0], [0.0], [90.0], [180.0]])),
+        (torch.tensor(1e6), torch.tensor([0.0, 180.0])),
     ],
     ids=["off", "mixed", "on"],
 )

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -35,11 +35,11 @@ def test_assert_ei_greater_zero():
 @pytest.mark.parametrize(
     ("voltage", "phase"),
     [
-        (torch.tensor(0.0), torch.tensor(-90.0)),
+        (torch.tensor(0.0), torch.tensor([-90.0, 90.0])),
+        (torch.tensor([0.0, 1e6]), torch.tensor([[-90.0], [90.0], [0.0]])),
         (torch.tensor(1e6), torch.tensor(0.0)),
-        (torch.tensor([0.0, 1e6]), torch.tensor([[-90.0], [0.0]])),
     ],
-    ids=["off", "on", "mixed"],
+    ids=["off", "mixed", "on"],
 )
 @pytest.mark.parametrize("cavity_type", ["standing_wave", "traveling_wave"])
 def test_vectorized_inactive_cavity(cavity_type, voltage, phase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

For cavities with 0 voltage, the numerical issues were already caught. However, the same issue appears for cavities that are fully off-crest in phase, i.e. -90 deg.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)
  - closes #548 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
