### PR TITLE
Maintain particle species in space charge kick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Shorten `__repr__` of `Segment` for large lattices to prevent debugging slowdowns (see #529) (@Hespe)
 - Fix typo saying Bmad in Elegant import method docstring (see #531) (@jank324)
 - Remove division by zero in `Cavity` for off-crest phase (see #549, #550) (@Hespe)
+- Fix issue with `SpaceChargeKick` where the particle species was not preserved (see #560) (@austin-hoover)
 
 ### 🐆 Other
 
@@ -34,6 +35,7 @@
 ### 🌟 First Time Contributors
 
 - Zihan Zhu (@zihan-zh)
+- Austin Hoover (@austin-hoover)
 
 ## [v0.7.5](https://github.com/desy-ml/cheetah/releases/tag/v0.7.5) (2025-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Shorten `__repr__` of `Segment` for large lattices to prevent debugging slowdowns (see #529) (@Hespe)
 - Fix typo saying Bmad in Elegant import method docstring (see #531) (@jank324)
 - Remove division by zero in `Cavity` for off-crest phase (see #549, #550) (@Hespe)
-- Fix issue with `SpaceChargeKick` where the particle species was not preserved (see #560) (@austin-hoover)
+- Fix issue with `SpaceChargeKick` where the particle species was not preserved (see #560) (@austin-hoover, @jank324)
 
 ### 🐆 Other
 

--- a/cheetah/accelerator/space_charge_kick.py
+++ b/cheetah/accelerator/space_charge_kick.py
@@ -593,6 +593,7 @@ class SpaceChargeKick(Element):
                 incoming.survival_probabilities,
                 (*vector_shape, incoming.num_particles),
             ),
+            species=incoming.species,
             device=incoming.particles.device,
             dtype=incoming.particles.dtype,
         )
@@ -604,6 +605,7 @@ class SpaceChargeKick(Element):
             survival_probabilities=(
                 vectorized_incoming.survival_probabilities.flatten(end_dim=-2)
             ),
+            species=incoming.species,
             device=vectorized_incoming.particles.device,
             dtype=vectorized_incoming.particles.dtype,
         )

--- a/tests/test_space_charge_kick.py
+++ b/tests/test_space_charge_kick.py
@@ -413,37 +413,16 @@ def test_space_charge_with_aperture_cutoff():
     assert outgoing_beam_with_aperture.survival_probabilities.sum(dim=-1).max() < 10_000
 
 
-def test_species():
+def test_species_preservation():
     """
-    Tests that particle species is preserved by space charge kick.
+    Test that the beam's species is preserved when tracking through a `SpaceChargeKick`
+    element.
     """
-    species = cheetah.Species("proton")
-    rest_energy = (
-        species.mass_kg
-        * constants.speed_of_light**2
-        / species.charge_coulomb
-    )
-    kin_energy = torch.tensor(2.5e-6)
-    energy = rest_energy + kin_energy
-    gamma = energy / rest_energy
-    beta = torch.sqrt(1.0 - 1.0 / gamma**2)
-
-    R0 = torch.tensor(0.001)
-
-    beam = cheetah.ParticleBeam.uniform_3d_ellipsoid(
-        num_particles=10_000,
-        total_charge=torch.tensor(1e-8),
-        energy=energy,
-        species=species,
-        radius_x=R0,
-        radius_y=R0,
-        radius_tau=R0 / gamma / beta,
-        sigma_px=torch.tensor(1e-15),
-        sigma_py=torch.tensor(1e-15),
-        sigma_p=torch.tensor(1e-15),
+    incoming = cheetah.ParticleBeam.uniform_3d_ellipsoid(
+        species=cheetah.Species("proton")
     )
 
-    element = cheetah.SpaceChargeKick(effect_length=torch.tensor(0.1))
-    beam_out = element.track(beam)
+    space_charge_kick = cheetah.SpaceChargeKick(effect_length=torch.tensor(0.1))
+    outgoing = space_charge_kick.track(incoming)
 
-    assert beam_out.species == beam.species
+    assert outgoing.species == incoming.species


### PR DESCRIPTION
## Description

Maintain particle species in `SpaceChargeKick` element.

## Motivation and Context

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

`SpaceChargeKick` creates new `ParticleBeam` objects but does not preserve the species of the incoming beam. The species defaults to "electron". https://github.com/desy-ml/cheetah/blob/master/cheetah/accelerator/space_charge_kick.py#L584C1-L610C73

Closes #443.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [x] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
