### PR TITLE
Patch emittance `NaN` and `0.0` conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Update the elegant conversion to include missing dipole attributes, converting `hgap` to `gap` and `fint` to `fringe_integral`. (see #624) (@cr-xu)
 - Update the `to_openpmd_particlegroup` conversion to use `int` for status and add `detach()` before tensor to numpy conversion. (see #629) (@roussel-ryan)
 - Fix an issue where negative length elements are incorrectly removed by the `Segment.without_inactive_zero_length_elements` method (see #633) (@cr-xu)
+- Patch emittance `NaN` and `0.0` conditions, which caused Twiss parameters to be `NaN` or `inf` under some conditions. (see #639) (@jank324)
 
 ### 🐆 Other
 

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -460,8 +460,8 @@ class Beam(ABC, nn.Module):
                     ).square()
                 )
             )
+            .clamp_min(torch.finfo(self.sigma_x.dtype).tiny)
             .sqrt()
-            .nan_to_num(torch.finfo(self.sigma_x.dtype).tiny)
         )
 
     @property
@@ -510,8 +510,8 @@ class Beam(ABC, nn.Module):
                     self.cov_ypy - self.cov_yp * self.cov_pyp / self.sigma_p.square()
                 ).square()
             )
+            .clamp_min(torch.finfo(self.sigma_y.dtype).tiny)
             .sqrt()
-            .nan_to_num(torch.finfo(self.sigma_y.dtype).tiny)
         )
 
     @property

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -460,7 +460,7 @@ class Beam(ABC, nn.Module):
                     ).square()
                 )
             )
-            .clamp_min(torch.finfo(self.sigma_x.dtype).tiny)
+            .clamp_min(torch.finfo(self.sigma_x.dtype).tiny)  # Patch NaN and 0.0 (#639)
             .sqrt()
         )
 
@@ -510,7 +510,7 @@ class Beam(ABC, nn.Module):
                     self.cov_ypy - self.cov_yp * self.cov_pyp / self.sigma_p.square()
                 ).square()
             )
-            .clamp_min(torch.finfo(self.sigma_y.dtype).tiny)
+            .clamp_min(torch.finfo(self.sigma_y.dtype).tiny)  # Patch NaN and 0.0 (#639)
             .sqrt()
         )
 

--- a/cheetah/particles/beam.py
+++ b/cheetah/particles/beam.py
@@ -445,16 +445,24 @@ class Beam(ABC, nn.Module):
         """
         return (
             (
-                (self.sigma_x.square() - self.cov_xp.square() / self.sigma_p.square())
-                * (
-                    self.sigma_px.square()
-                    - self.cov_pxp.square() / self.sigma_p.square()
+                (
+                    (
+                        self.sigma_x.square()
+                        - self.cov_xp.square() / self.sigma_p.square()
+                    )
+                    * (
+                        self.sigma_px.square()
+                        - self.cov_pxp.square() / self.sigma_p.square()
+                    )
+                    - (
+                        self.cov_xpx
+                        - self.cov_xp * self.cov_pxp / self.sigma_p.square()
+                    ).square()
                 )
-                - (
-                    self.cov_xpx - self.cov_xp * self.cov_pxp / self.sigma_p.square()
-                ).square()
             )
-        ).sqrt()
+            .sqrt()
+            .nan_to_num(torch.finfo(self.sigma_x.dtype).tiny)
+        )
 
     @property
     def normalized_emittance_x(self) -> torch.Tensor:
@@ -492,12 +500,19 @@ class Beam(ABC, nn.Module):
         This is computed with the dispersion correction.
         """
         return (
-            (self.sigma_y.square() - self.cov_yp.square() / self.sigma_p.square())
-            * (self.sigma_py.square() - self.cov_pyp.square() / self.sigma_p.square())
-            - (
-                self.cov_ypy - self.cov_yp * self.cov_pyp / self.sigma_p.square()
-            ).square()
-        ).sqrt()
+            (
+                (self.sigma_y.square() - self.cov_yp.square() / self.sigma_p.square())
+                * (
+                    self.sigma_py.square()
+                    - self.cov_pyp.square() / self.sigma_p.square()
+                )
+                - (
+                    self.cov_ypy - self.cov_yp * self.cov_pyp / self.sigma_p.square()
+                ).square()
+            )
+            .sqrt()
+            .nan_to_num(torch.finfo(self.sigma_y.dtype).tiny)
+        )
 
     @property
     def normalized_emittance_y(self) -> torch.Tensor:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Under some edge conditions it is possible that floating point arithmetic causes the emittance values of a beam to become 0.0 or a very small negative value, causing Twiss parameters computed from them to become `NaN` or `Inf`. These conditions occur often enough to disturb ML processes. Once such a condition occurs, the gradients under that condition is useless anyway, so clamping to a constant numerically useful value is fine as well ... and at least avoids `NaN`s and `Inf`s.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

`NaN`s and `Inf`s coming from randomised Cheetah simulations, especially for Twiss parameter values.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [x] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
