### PR TITLE
Implement experimental `PALS` converter interfacing with the `pals-python` project

### DIFF
--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -338,6 +338,72 @@ class Segment(Element):
         latticejson.save_cheetah_model(self, filepath, title, info)
 
     @classmethod
+    def from_pals(
+        cls,
+        obj: Any,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> "Segment":
+        """
+        Convert a PALS object to a Cheetah `Segment`.
+
+        :param obj: PALS object to convert. May be a `Lattice`, `BeamLine`,
+            `PALSroot`, or individual PALS element.
+        :param device: Device to place the lattice elements on. If `None`, the
+            current default PyTorch device is used.
+        :param dtype: Data type to use for the lattice elements. If `None`, the
+            current default PyTorch dtype is used.
+        :return: Cheetah `Segment` representing the PALS object.
+        """
+        from cheetah.converters import pals
+
+        return pals.convert_lattice_from_pals(obj, device=device, dtype=dtype)
+
+    def to_pals(self, name: str = "lattice") -> Any:
+        """
+        Convert this Cheetah segment to a PALS `Lattice`.
+
+        :param name: Name to give the generated PALS `Lattice`.
+        :return: PALS `Lattice` representing this segment.
+        """
+        from cheetah.converters import pals
+
+        return pals.convert_lattice_to_pals(self, name=name)
+
+    @classmethod
+    def from_pals_file(
+        cls,
+        filename: str | Path,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> "Segment":
+        """
+        Load a Cheetah segment from a PALS file.
+
+        :param filename: Path to the PALS file to read.
+        :param device: Device to place the lattice elements on. If `None`, the
+            current default PyTorch device is used.
+        :param dtype: Data type to use for the lattice elements. If `None`, the
+            current default PyTorch dtype is used.
+        :return: Cheetah `Segment` loaded from the PALS file.
+        """
+        from cheetah.converters import pals
+
+        return pals.load_lattice_from_pals(filename, device=device, dtype=dtype)
+
+    def to_pals_file(self, filename: str | Path, name: str = "lattice") -> None:
+        """
+        Save this Cheetah segment as a PALS file.
+
+        :param filename: Path to the PALS file to write.
+        :param name: Name to give the generated PALS `Lattice`.
+        :return: None.
+        """
+        from cheetah.converters import pals
+
+        pals.save_lattice_to_pals(self, filename, name=name)
+
+    @classmethod
     def from_ocelot(
         cls,
         cell,

--- a/cheetah/accelerator/segment.py
+++ b/cheetah/accelerator/segment.py
@@ -347,6 +347,9 @@ class Segment(Element):
         """
         Convert a PALS object to a Cheetah `Segment`.
 
+        PALS does not encode Cheetah-only simulation settings such as
+        `tracking_method`; set those manually on the returned elements as needed.
+
         :param obj: PALS object to convert. May be a `Lattice`, `BeamLine`,
             `PALSroot`, or individual PALS element.
         :param device: Device to place the lattice elements on. If `None`, the
@@ -379,6 +382,9 @@ class Segment(Element):
     ) -> "Segment":
         """
         Load a Cheetah segment from a PALS file.
+
+        PALS does not encode Cheetah-only simulation settings such as
+        `tracking_method`; set those manually on the returned elements as needed.
 
         :param filename: Path to the PALS file to read.
         :param device: Device to place the lattice elements on. If `None`, the

--- a/cheetah/converters/pals.py
+++ b/cheetah/converters/pals.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import warnings
+from copy import deepcopy
+from math import degrees, inf, isclose, isinf, isnan, radians
+from pathlib import Path
+from typing import Any
+
+import torch
+
+import cheetah
+from cheetah.utils import UnknownElementWarning
+
+
+def _import_pals():
+    try:
+        import pals
+    except ImportError as exc:
+        raise ImportError(
+            "To use the PALS converter, install the PALS Python package "
+            "`pals_schema`."
+        ) from exc
+
+    return pals
+
+
+def _factory_kwargs(
+    device: torch.device | str | None = None,
+    dtype: torch.dtype | None = None,
+) -> dict:
+    """Factory kwargs for converted tensors.
+
+    :param device: The device to create converted tensors on. If `None`, uses
+        the default PyTorch device.
+    :param dtype: The dtype to create converted tensors with. If `None`, uses
+        the default PyTorch dtype.
+    :return: A dictionary of keyword arguments to pass to tensor constructors
+        when converting element parameters.
+    """
+    default_device = torch.get_default_device()
+    return {
+        "device": torch.device(device) if device is not None else default_device,
+        "dtype": dtype if dtype is not None else torch.get_default_dtype(),
+    }
+
+
+def _t2f(value: torch.Tensor) -> float:
+    """Convert a scalar tensor to a float.
+    :param value: A scalar tensor to convert.
+    :return: The float value of the tensor.
+    """
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"Expected a torch.Tensor, got {type(value).__name__}.")
+    if value.numel() != 1:
+        raise ValueError(
+            "PALS conversion only supports scalar element parameters. "
+            "Slice batched tensors before converting."
+        )
+    return float(value.detach().cpu().item())
+
+
+def _f2t(value: Any, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    return torch.tensor(value, device=device, dtype=dtype)
+
+
+def _nonnegative_length(value: torch.Tensor, element_name: str) -> float:
+    """Currently PALS requires thick elements with non-negative length."""
+    length = _t2f(value)
+    if length < 0:
+        raise ValueError(
+            f"Element {element_name!r} has negative length {length}; PALS lengths "
+            "must be non-negative."
+        )
+    return length
+
+
+def _is_zero(value: torch.Tensor) -> bool:
+    return torch.allclose(value, torch.zeros_like(value))
+
+
+def _require_default(condition: bool, message: str) -> None:
+    if not condition:
+        raise NotImplementedError(message)
+
+
+def _pals_payload(element) -> dict:
+    dumped = element.model_dump()
+    if hasattr(element, "name") and isinstance(dumped, dict) and element.name in dumped:
+        return deepcopy(dumped[element.name])
+    return deepcopy(dumped)
+
+
+def _model_dump_or_empty(model) -> dict:
+    return deepcopy(model.model_dump()) if model is not None else {}
+
+
+def _attach_pals_extras(element: cheetah.Element, extras: dict) -> cheetah.Element:
+    if extras:
+        element.pals_extras = extras
+    return element
+
+
+def _split_pals_extras(element: cheetah.Element) -> tuple[dict, dict]:
+    extras = deepcopy(getattr(element, "pals_extras", {}))
+    if not isinstance(extras, dict):
+        raise TypeError(f"{element.name}.pals_extras must be a dictionary.")
+    return extras.pop("_cheetah", {}), extras
+
+
+def _extract_extras(
+    element,
+    consumed_fields: set[str] | None = None,
+    consumed_groups: dict[str, set[str] | None] | None = None,
+    converter_metadata: dict | None = None,
+) -> dict:
+    """Extract extras from a PALS element during conversion to a Cheetah element."""
+    consumed_fields = consumed_fields or set()
+    consumed_groups = consumed_groups or {}
+    payload = _pals_payload(element)
+
+    payload.pop("kind", None)
+    payload.pop("name", None)
+    for field in consumed_fields:
+        payload.pop(field, None)
+
+    extras = {}
+    for key, value in payload.items():
+        if key not in consumed_groups:
+            extras[key] = value
+            continue
+
+        consumed = consumed_groups[key]
+        if consumed is None:
+            continue
+
+        remaining = deepcopy(value)
+        for consumed_key in consumed:
+            remaining.pop(consumed_key, None)
+        if remaining:
+            extras[key] = remaining
+
+    if converter_metadata:
+        extras["_cheetah"] = converter_metadata
+
+    return extras
+
+
+def _merge_group(pals, group_name: str, base: dict, extras: dict) -> Any:
+    group_data = deepcopy(extras.pop(group_name, {}))
+    group_data.update(base)
+    if not group_data:
+        return None
+
+    group_class = getattr(pals, group_name.removesuffix("P") + "Parameters", None)
+    if group_class is None:
+        return group_data
+    return group_class(**group_data)
+
+
+def _common_kwargs_from_extras(pals_cls, extras: dict) -> dict:
+    valid_fields = set(pals_cls.model_fields)
+    kwargs = {}
+    for key in list(extras):
+        if key in valid_fields:
+            kwargs[key] = extras.pop(key)
+    if extras:
+        raise NotImplementedError(
+            f"Cannot re-emit unsupported PALS extras: {sorted(extras)}."
+        )
+    return kwargs
+
+
+def _multipole_value(multipole: dict, order: int) -> tuple[float, str | None]:
+    for key in (f"Kn{order}", f"Bn{order}"):
+        if key in multipole:
+            return multipole[key], key
+    return 0.0, None
+
+
+def _tilt_value(multipole: dict, order: int) -> float:
+    return multipole.get(f"tilt{order}", 0.0)
+
+
+def _aperture_limits_from_extent(
+    value: torch.Tensor, element_name: str, plane: str
+) -> list[float | None]:
+    extent = _t2f(value)
+    if isnan(extent) or extent < 0:
+        raise ValueError(
+            f"Aperture {element_name!r} has invalid {plane}_max={extent}; "
+            "PALS conversion requires a non-negative aperture half width."
+        )
+    if isinf(extent):
+        return [None, None]
+    return [-extent, extent]
+
+
+def _extent_from_aperture_limits(
+    limits: list[float | None], element_name: str, plane: str
+) -> float:
+    if limits == [None, None]:
+        return inf
+
+    lower, upper = limits
+    if lower is None or upper is None:
+        raise NotImplementedError(
+            f"PALS aperture {element_name!r} has one-sided {plane}_limits; "
+            "Cheetah Aperture requires symmetric limits."
+        )
+    if not isclose(lower, -upper):
+        raise NotImplementedError(
+            f"PALS aperture {element_name!r} has asymmetric {plane}_limits; "
+            "Cheetah Aperture requires symmetric limits."
+        )
+    return abs(upper)
+
+
+def _aperture_shape_to_pals(shape: str, element_name: str) -> str:
+    if shape == "rectangular":
+        return "RECTANGULAR"
+    if shape == "elliptical":
+        return "ELLIPTICAL"
+    raise NotImplementedError(
+        f"Aperture {element_name!r} uses unsupported shape {shape!r}."
+    )
+
+
+def _aperture_shape_from_pals(shape: str, element_name: str) -> str:
+    if shape == "RECTANGULAR":
+        return "rectangular"
+    if shape == "ELLIPTICAL":
+        return "elliptical"
+    raise NotImplementedError(
+        f"PALS aperture {element_name!r} uses unsupported shape {shape!r}."
+    )
+
+
+# Start Element converters
+def _drift_to_pals(element: cheetah.Drift, pals):
+    _require_default(
+        element.tracking_method == "linear",
+        f"Drift {element.name!r} uses unsupported tracking_method "
+        f"{element.tracking_method!r}.",
+    )
+    _, extras = _split_pals_extras(element)
+    kwargs = _common_kwargs_from_extras(pals.Drift, extras)
+    return pals.Drift(
+        name=element.name,
+        length=_nonnegative_length(element.length, element.name),
+        **kwargs,
+    )
+
+
+def _drift_from_pals(element, factory_kwargs: dict) -> cheetah.Drift:
+    converted = cheetah.Drift(
+        length=_f2t(element.length, **factory_kwargs),
+        name=element.name,
+    )
+    extras = _extract_extras(element, consumed_fields={"length"})
+    return _attach_pals_extras(converted, extras)
+
+
+def _marker_to_pals(element: cheetah.Marker, pals):
+    _, extras = _split_pals_extras(element)
+    kwargs = _common_kwargs_from_extras(pals.Marker, extras)
+    return pals.Marker(name=element.name, **kwargs)
+
+
+def _marker_from_pals(element, factory_kwargs: dict) -> cheetah.Element:
+    if element.ApertureP is not None:
+        return _aperture_from_pals(element, factory_kwargs)
+
+    converted = cheetah.Marker(name=element.name, **factory_kwargs)
+    extras = _extract_extras(element, consumed_fields={"length"})
+    return _attach_pals_extras(converted, extras)
+
+
+def _aperture_to_pals(element: cheetah.Aperture, pals):
+    _, extras = _split_pals_extras(element)
+    aperture_data = {
+        "x_limits": _aperture_limits_from_extent(element.x_max, element.name, "x"),
+        "y_limits": _aperture_limits_from_extent(element.y_max, element.name, "y"),
+        "shape": _aperture_shape_to_pals(element.shape, element.name),
+        "aperture_active": element.is_active,
+    }
+    aperture = _merge_group(pals, "ApertureP", aperture_data, extras)
+    kwargs = _common_kwargs_from_extras(pals.Marker, extras)
+    return pals.Marker(name=element.name, ApertureP=aperture, **kwargs)
+
+
+def _aperture_from_pals(element, factory_kwargs: dict) -> cheetah.Aperture:
+    aperture = _model_dump_or_empty(element.ApertureP)
+    converted = cheetah.Aperture(
+        x_max=_f2t(
+            _extent_from_aperture_limits(
+                aperture.get("x_limits", [None, None]), element.name, "x"
+            ),
+            **factory_kwargs,
+        ),
+        y_max=_f2t(
+            _extent_from_aperture_limits(
+                aperture.get("y_limits", [None, None]), element.name, "y"
+            ),
+            **factory_kwargs,
+        ),
+        shape=_aperture_shape_from_pals(
+            aperture.get("shape", "RECTANGULAR"), element.name
+        ),
+        is_active=aperture.get("aperture_active", True),
+        name=element.name,
+        **factory_kwargs,
+    )
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={
+            "ApertureP": {
+                "x_limits",
+                "y_limits",
+                "shape",
+                "aperture_active",
+            }
+        },
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _quad_to_pals(element: cheetah.Quadrupole, pals):
+    _require_default(
+        element.tracking_method == "linear",
+        f"Quadrupole {element.name!r} uses unsupported tracking_method "
+        f"{element.tracking_method!r}.",
+    )
+    _require_default(
+        element.num_steps == 1,
+        f"Quadrupole {element.name!r} has unsupported num_steps={element.num_steps}.",
+    )
+    _require_default(
+        _is_zero(element.misalignment),
+        f"Quadrupole {element.name!r} has unsupported misalignment.",
+    )
+
+    metadata, extras = _split_pals_extras(element)
+    k1_key = metadata.get("k1_key", "Kn1")
+    multipole_data = {
+        k1_key: _t2f(element.k1),
+    }
+    if not _is_zero(element.tilt) or metadata.get("tilt1_present", False):
+        multipole_data["tilt1"] = _t2f(element.tilt)
+    multipole = _merge_group(pals, "MagneticMultipoleP", multipole_data, extras)
+    kwargs = _common_kwargs_from_extras(pals.Quadrupole, extras)
+
+    return pals.Quadrupole(
+        name=element.name,
+        length=_nonnegative_length(element.length, element.name),
+        MagneticMultipoleP=multipole,
+        **kwargs,
+    )
+
+
+def _quad_from_pals(element, factory_kwargs: dict) -> cheetah.Quadrupole:
+    multipole = _model_dump_or_empty(element.MagneticMultipoleP)
+    if element.MagneticMultipoleP is None and element.ElectricMultipoleP is not None:
+        warnings.warn(
+            f"PALS Quadrupole {element.name!r} has no magnetic multipole; "
+            "using Marker.",
+            category=UnknownElementWarning,
+            stacklevel=2,
+        )
+        return _unknown_from_pals(element, factory_kwargs)
+
+    k1, k1_key = _multipole_value(multipole, 1)
+    tilt = _tilt_value(multipole, 1)
+    converted = cheetah.Quadrupole(
+        length=_f2t(element.length, **factory_kwargs),
+        k1=_f2t(k1, **factory_kwargs),
+        tilt=_f2t(tilt, **factory_kwargs),
+        name=element.name,
+    )
+
+    consumed = set()
+    if k1_key is not None:
+        consumed.add(k1_key)
+    if "tilt1" in multipole:
+        consumed.add("tilt1")
+    metadata = {}
+    if k1_key is not None:
+        metadata["k1_key"] = k1_key
+    if "tilt1" in multipole:
+        metadata["tilt1_present"] = True
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={"MagneticMultipoleP": consumed},
+        converter_metadata=metadata or None,
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _dipole_to_pals(element: cheetah.Dipole, pals):
+    _require_default(
+        element.tracking_method == "linear",
+        f"Dipole {element.name!r} uses unsupported tracking_method "
+        f"{element.tracking_method!r}.",
+    )
+    _require_default(
+        _is_zero(element.gap) and _is_zero(element.gap_exit),
+        f"Dipole {element.name!r} has unsupported gap settings.",
+    )
+    _require_default(
+        element.fringe_at == "both",
+        f"Dipole {element.name!r} has unsupported fringe_at={element.fringe_at!r}.",
+    )
+    _require_default(
+        element.fringe_type == "linear_edge",
+        f"Dipole {element.name!r} has unsupported fringe_type={element.fringe_type!r}.",
+    )
+
+    metadata, extras = _split_pals_extras(element)
+    length = _nonnegative_length(element.length, element.name)
+    angle = _t2f(element.angle)
+    if length == 0.0 and angle != 0.0:
+        raise ValueError(f"Dipole {element.name!r} has nonzero angle and zero length.")
+
+    bend_data = {
+        "e1": _t2f(element.dipole_e1),
+        "e2": _t2f(element.dipole_e2),
+        "edge_int1": _t2f(element.fringe_integral),
+        "edge_int2": _t2f(element.fringe_integral_exit),
+        "tilt_ref": _t2f(element.tilt),
+    }
+    if metadata.get("angle_key") == "rho_ref":
+        bend_data["rho_ref"] = length / angle if angle != 0.0 else 0.0
+    else:
+        bend_data["g_ref"] = angle / length if length != 0.0 else 0.0
+
+    bend = _merge_group(pals, "BendP", bend_data, extras)
+
+    multipole = None
+    multipole_extras = extras.get("MagneticMultipoleP", {})
+    if not _is_zero(element.k1) or multipole_extras:
+        k1_key = metadata.get("k1_key", "Kn1")
+        multipole_data = {k1_key: _t2f(element.k1)}
+        multipole = _merge_group(pals, "MagneticMultipoleP", multipole_data, extras)
+
+    kwargs = _common_kwargs_from_extras(pals.SBend, extras)
+    return pals.SBend(
+        name=element.name,
+        length=length,
+        BendP=bend,
+        MagneticMultipoleP=multipole,
+        **kwargs,
+    )
+
+
+def _dipole_from_pals(element, factory_kwargs: dict) -> cheetah.Dipole:
+    bend = _model_dump_or_empty(element.BendP)
+    multipole = _model_dump_or_empty(element.MagneticMultipoleP)
+    length = element.length
+
+    angle_key = "g_ref"
+    if bend.get("g_ref", 0.0) != 0.0:
+        angle = bend["g_ref"] * length
+    elif bend.get("rho_ref", 0.0) != 0.0:
+        angle_key = "rho_ref"
+        angle = length / bend["rho_ref"]
+    else:
+        angle = 0.0
+
+    k1, k1_key = _multipole_value(multipole, 1)
+    converted = cheetah.Dipole(
+        length=_f2t(length, **factory_kwargs),
+        angle=_f2t(angle, **factory_kwargs),
+        k1=_f2t(k1, **factory_kwargs),
+        dipole_e1=_f2t(bend.get("e1", 0.0), **factory_kwargs),
+        dipole_e2=_f2t(bend.get("e2", 0.0), **factory_kwargs),
+        tilt=_f2t(bend.get("tilt_ref", 0.0), **factory_kwargs),
+        fringe_integral=_f2t(bend.get("edge_int1", 0.0), **factory_kwargs),
+        fringe_integral_exit=_f2t(bend.get("edge_int2", 0.0), **factory_kwargs),
+        name=element.name,
+    )
+
+    bend_consumed = {"e1", "e2", "edge_int1", "edge_int2", "tilt_ref", angle_key}
+    multipole_consumed = set()
+    if k1_key is not None:
+        multipole_consumed.add(k1_key)
+    metadata = {"angle_key": angle_key}
+    if k1_key is not None:
+        metadata["k1_key"] = k1_key
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={
+            "BendP": bend_consumed,
+            "MagneticMultipoleP": multipole_consumed,
+        },
+        converter_metadata=metadata,
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _cavity_to_pals(element: cheetah.Cavity, pals):
+    _require_default(
+        element.cavity_type == "standing_wave",
+        f"Cavity {element.name!r} has unsupported cavity_type="
+        f"{element.cavity_type!r}.",
+    )
+
+    _, extras = _split_pals_extras(element)
+    rf_data = {
+        "frequency": _t2f(element.frequency),
+        "voltage": _t2f(element.voltage),
+        "phase": radians(_t2f(element.phase)),
+        "cavity_type": "STANDING_WAVE",
+    }
+    rf = _merge_group(pals, "RFP", rf_data, extras)
+    kwargs = _common_kwargs_from_extras(pals.RFCavity, extras)
+    return pals.RFCavity(
+        name=element.name,
+        length=_nonnegative_length(element.length, element.name),
+        RFP=rf,
+        **kwargs,
+    )
+
+
+def _cavity_from_pals(element, factory_kwargs: dict) -> cheetah.Cavity:
+    rf = _model_dump_or_empty(element.RFP)
+    converted = cheetah.Cavity(
+        length=_f2t(element.length, **factory_kwargs),
+        voltage=_f2t(rf.get("voltage", 0.0), **factory_kwargs),
+        phase=_f2t(degrees(rf.get("phase", 0.0)), **factory_kwargs),
+        frequency=_f2t(rf.get("frequency", 0.0), **factory_kwargs),
+        cavity_type="standing_wave",
+        name=element.name,
+    )
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={"RFP": {"frequency", "voltage", "phase", "cavity_type"}},
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _corrector_multipole_to_pals(element: cheetah.Element, pals, data: dict):
+    _, extras = _split_pals_extras(element)
+    multipole = _merge_group(pals, "MagneticMultipoleP", data, extras)
+    kwargs = _common_kwargs_from_extras(pals.Kicker, extras)
+    return pals.Kicker(
+        name=element.name,
+        length=_nonnegative_length(element.length, element.name),
+        MagneticMultipoleP=multipole,
+        **kwargs,
+    )
+
+
+def _horizontal_corrector_to_pals(element: cheetah.HorizontalCorrector, pals):
+    return _corrector_multipole_to_pals(
+        element,
+        pals,
+        {"Kn0": _t2f(element.angle)},
+    )
+
+
+def _vertical_corrector_to_pals(element: cheetah.VerticalCorrector, pals):
+    return _corrector_multipole_to_pals(
+        element,
+        pals,
+        {"Ks0": _t2f(element.angle)},
+    )
+
+
+def _combined_corrector_to_pals(element: cheetah.CombinedCorrector, pals):
+    return _corrector_multipole_to_pals(
+        element,
+        pals,
+        {
+            "Kn0": _t2f(element.horizontal_angle),
+            "Ks0": _t2f(element.vertical_angle),
+        },
+    )
+
+
+def _kicker_from_pals(element, factory_kwargs: dict) -> cheetah.Element:
+    multipole = _model_dump_or_empty(element.MagneticMultipoleP)
+    has_horizontal_angle = "Kn0" in multipole
+    has_vertical_angle = "Ks0" in multipole
+    horizontal_angle = multipole.get("Kn0", 0.0)
+    vertical_angle = multipole.get("Ks0", 0.0)
+    length = _f2t(element.length, **factory_kwargs)
+
+    if has_horizontal_angle and has_vertical_angle:
+        converted = cheetah.CombinedCorrector(
+            length=length,
+            horizontal_angle=_f2t(horizontal_angle, **factory_kwargs),
+            vertical_angle=_f2t(vertical_angle, **factory_kwargs),
+            name=element.name,
+        )
+    elif has_vertical_angle:
+        converted = cheetah.VerticalCorrector(
+            length=length,
+            angle=_f2t(vertical_angle, **factory_kwargs),
+            name=element.name,
+        )
+    else:
+        converted = cheetah.HorizontalCorrector(
+            length=length,
+            angle=_f2t(horizontal_angle, **factory_kwargs),
+            name=element.name,
+        )
+
+    consumed = set()
+    if "Kn0" in multipole:
+        consumed.add("Kn0")
+    if "Ks0" in multipole:
+        consumed.add("Ks0")
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={"MagneticMultipoleP": consumed},
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _solenoid_to_pals(element: cheetah.Solenoid, pals):
+    _require_default(
+        _is_zero(element.misalignment),
+        f"Solenoid {element.name!r} has unsupported misalignment.",
+    )
+
+    _, extras = _split_pals_extras(element)
+    solenoid = _merge_group(
+        pals,
+        "SolenoidP",
+        {"Ksol": _t2f(element.k)},
+        extras,
+    )
+    kwargs = _common_kwargs_from_extras(pals.Solenoid, extras)
+    return pals.Solenoid(
+        name=element.name,
+        length=_nonnegative_length(element.length, element.name),
+        SolenoidP=solenoid,
+        **kwargs,
+    )
+
+
+def _solenoid_from_pals(element, factory_kwargs: dict) -> cheetah.Solenoid:
+    solenoid = _model_dump_or_empty(element.SolenoidP)
+    converted = cheetah.Solenoid(
+        length=_f2t(element.length, **factory_kwargs),
+        k=_f2t(solenoid.get("Ksol", 0.0), **factory_kwargs),
+        name=element.name,
+    )
+    extras = _extract_extras(
+        element,
+        consumed_fields={"length"},
+        consumed_groups={"SolenoidP": {"Ksol"}},
+    )
+    return _attach_pals_extras(converted, extras)
+
+
+def _unknown_to_pals(element: cheetah.Element, pals):
+    raise NotImplementedError(
+        f"Cheetah element {element.name!r} of type {element.__class__.__name__} "
+        "is not supported by the PALS converter."
+    )
+
+
+def _unknown_from_pals(element, factory_kwargs: dict) -> cheetah.Marker:
+    warnings.warn(
+        f"PALS element {element.name!r} of kind {element.kind!r} is not supported by "
+        "the PALS converter. Using Marker.",
+        category=UnknownElementWarning,
+        stacklevel=2,
+    )
+    converted = cheetah.Marker(name=element.name)
+    converted.pals_extras = _pals_payload(element)
+    return converted
+
+
+_TO_PALS = {
+    cheetah.Aperture: _aperture_to_pals,
+    cheetah.Cavity: _cavity_to_pals,
+    cheetah.CombinedCorrector: _combined_corrector_to_pals,
+    cheetah.Drift: _drift_to_pals,
+    cheetah.HorizontalCorrector: _horizontal_corrector_to_pals,
+    cheetah.Marker: _marker_to_pals,
+    cheetah.Quadrupole: _quad_to_pals,
+    cheetah.Dipole: _dipole_to_pals,
+    cheetah.Solenoid: _solenoid_to_pals,
+    cheetah.VerticalCorrector: _vertical_corrector_to_pals,
+}
+
+_FROM_PALS = {
+    "Drift": _drift_from_pals,
+    "Kicker": _kicker_from_pals,
+    "Marker": _marker_from_pals,
+    "Quadrupole": _quad_from_pals,
+    "RFCavity": _cavity_from_pals,
+    "SBend": _dipole_from_pals,
+    "Solenoid": _solenoid_from_pals,
+}
+
+
+def _element_to_pals(element: cheetah.Element, pals):
+    if isinstance(element, cheetah.Segment):
+        return _segment_to_beamline(element, pals, element.name)
+
+    converter = _TO_PALS.get(type(element), _unknown_to_pals)
+    return converter(element, pals)
+
+
+def _segment_to_beamline(segment: cheetah.Segment, pals, name: str | None):
+    return pals.BeamLine(
+        name=name or segment.name,
+        line=[_element_to_pals(element, pals) for element in segment.elements],
+    )
+
+
+def _element_from_pals(element, factory_kwargs: dict) -> cheetah.Element:
+    pals = _import_pals()
+    if isinstance(element, pals.PlaceholderName):
+        if element.element is None:
+            raise NotImplementedError(
+                f"Unresolved PALS element reference {element.name!r} cannot be "
+                "converted."
+            )
+        element = element.element
+
+    if isinstance(element, pals.BeamLine):
+        return _beamline_from_pals(element, factory_kwargs)
+    if isinstance(element, pals.Lattice):
+        return _lattice_from_pals(element, factory_kwargs)
+
+    # Look for existing converters based on the "kind" field
+    converter = _FROM_PALS.get(getattr(element, "kind", None), _unknown_from_pals)
+    return converter(element, factory_kwargs)
+
+
+def _beamline_from_pals(beamline, factory_kwargs: dict) -> cheetah.Segment:
+    return cheetah.Segment(
+        elements=[
+            _element_from_pals(element, factory_kwargs) for element in beamline.line
+        ],
+        name=beamline.name,
+    )
+
+
+def _lattice_from_pals(lattice, factory_kwargs: dict) -> cheetah.Segment:
+    if len(lattice.branches) != 1:
+        raise NotImplementedError(
+            "PALS conversion only supports Lattice objects with one branch."
+        )
+    return _element_from_pals(lattice.branches[0], factory_kwargs)
+
+
+def convert_lattice_to_pals(
+    segment: cheetah.Segment,
+    name: str = "lattice",
+):
+    """
+    Convert a Cheetah segment to a PALS Lattice.
+
+    :param segment: Cheetah `Segment` to convert.
+    :param name: Name to give the generated PALS `Lattice`.
+    :return: PALS `Lattice` representing the Cheetah segment.
+    """
+    pals = _import_pals()
+    if not isinstance(segment, cheetah.Segment):
+        raise TypeError("convert_lattice_to_pals expects a cheetah.Segment.")
+
+    branch_name = segment.name or f"{name}_line"
+    return pals.Lattice(
+        name=name,
+        branches=[_segment_to_beamline(segment, pals, branch_name)],
+    )
+
+
+def convert_lattice_from_pals(
+    obj,
+    *,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype | None = None,
+) -> cheetah.Segment:
+    """
+    Convert a PALS Lattice, BeamLine, or PALSroot to a Cheetah segment.
+
+    :param obj: PALS object to convert. May be a `Lattice`, `BeamLine`,
+        `PALSroot`, or individual PALS element.
+    :param device: Device to use for converted tensors. If `None`, uses the
+        current default PyTorch device.
+    :param dtype: Data type to use for converted tensors. If `None`, uses the
+        current default PyTorch dtype.
+    :return: Cheetah `Segment` representing the PALS object.
+    """
+    pals = _import_pals()
+    factory_kwargs = _factory_kwargs(device=device, dtype=dtype)
+
+    if isinstance(obj, pals.PALSroot):
+        if len(obj.facility) != 1:
+            raise NotImplementedError(
+                "PALS conversion only supports PALSroot objects with one "
+                "facility entry."
+            )
+        obj = obj.facility[0]
+
+    converted = _element_from_pals(obj, factory_kwargs)
+    if isinstance(converted, cheetah.Segment):
+        return converted
+    return cheetah.Segment(elements=[converted], name=getattr(obj, "name", "pals"))
+
+
+def save_lattice_to_pals(
+    segment: cheetah.Segment,
+    filename: str | Path,
+    name: str = "lattice",
+) -> None:
+    """
+    Save a Cheetah segment as a PALS file.
+
+    :param segment: Cheetah `Segment` to save.
+    :param filename: Path to the PALS file to write.
+    :param name: Name to give the generated PALS `Lattice`.
+    :return: None.
+    """
+    pals = _import_pals()
+    pals.store(
+        str(filename),
+        convert_lattice_to_pals(segment, name=name),
+    )
+
+
+def load_lattice_from_pals(
+    filename: str | Path,
+    *,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype | None = None,
+) -> cheetah.Segment:
+    """
+    Load a Cheetah segment from a PALS file.
+
+    :param filename: Path to the PALS file to read.
+    :param device: Device to use for converted tensors. If `None`, uses the
+        current default PyTorch device.
+    :param dtype: Data type to use for converted tensors. If `None`, uses the
+        current default PyTorch dtype.
+    :return: Cheetah `Segment` loaded from the PALS file.
+    """
+    pals = _import_pals()
+    return convert_lattice_from_pals(
+        pals.load(str(filename)), device=device, dtype=dtype
+    )

--- a/cheetah/converters/pals.py
+++ b/cheetah/converters/pals.py
@@ -63,17 +63,6 @@ def _f2t(value: Any, *, device: torch.device, dtype: torch.dtype) -> torch.Tenso
     return torch.tensor(value, device=device, dtype=dtype)
 
 
-def _nonnegative_length(value: torch.Tensor, element_name: str) -> float:
-    """Currently PALS requires thick elements with non-negative length."""
-    length = _t2f(value)
-    if length < 0:
-        raise ValueError(
-            f"Element {element_name!r} has negative length {length}; PALS lengths "
-            "must be non-negative."
-        )
-    return length
-
-
 def _is_zero(value: torch.Tensor) -> bool:
     return torch.allclose(value, torch.zeros_like(value))
 
@@ -235,18 +224,33 @@ def _aperture_shape_from_pals(shape: str, element_name: str) -> str:
     )
 
 
+def _body_shift_to_pals(pals, misalignment: torch.Tensor, extras: dict):
+    body_shift_extras = extras.get("BodyShiftP", {})
+    if _is_zero(misalignment) and not body_shift_extras:
+        return None
+
+    body_shift_data = {
+        "x_offset": _t2f(misalignment[..., 0]),
+        "y_offset": _t2f(misalignment[..., 1]),
+    }
+    return _merge_group(pals, "BodyShiftP", body_shift_data, extras)
+
+
+def _misalignment_from_body_shift(element, factory_kwargs: dict) -> torch.Tensor:
+    body_shift = _model_dump_or_empty(element.BodyShiftP)
+    return _f2t(
+        [body_shift.get("x_offset", 0.0), body_shift.get("y_offset", 0.0)],
+        **factory_kwargs,
+    )
+
+
 # Start Element converters
 def _drift_to_pals(element: cheetah.Drift, pals):
-    _require_default(
-        element.tracking_method == "linear",
-        f"Drift {element.name!r} uses unsupported tracking_method "
-        f"{element.tracking_method!r}.",
-    )
     _, extras = _split_pals_extras(element)
     kwargs = _common_kwargs_from_extras(pals.Drift, extras)
     return pals.Drift(
         name=element.name,
-        length=_nonnegative_length(element.length, element.name),
+        length=_t2f(element.length),
         **kwargs,
     )
 
@@ -327,17 +331,8 @@ def _aperture_from_pals(element, factory_kwargs: dict) -> cheetah.Aperture:
 
 def _quad_to_pals(element: cheetah.Quadrupole, pals):
     _require_default(
-        element.tracking_method == "linear",
-        f"Quadrupole {element.name!r} uses unsupported tracking_method "
-        f"{element.tracking_method!r}.",
-    )
-    _require_default(
         element.num_steps == 1,
         f"Quadrupole {element.name!r} has unsupported num_steps={element.num_steps}.",
-    )
-    _require_default(
-        _is_zero(element.misalignment),
-        f"Quadrupole {element.name!r} has unsupported misalignment.",
     )
 
     metadata, extras = _split_pals_extras(element)
@@ -348,11 +343,13 @@ def _quad_to_pals(element: cheetah.Quadrupole, pals):
     if not _is_zero(element.tilt) or metadata.get("tilt1_present", False):
         multipole_data["tilt1"] = _t2f(element.tilt)
     multipole = _merge_group(pals, "MagneticMultipoleP", multipole_data, extras)
+    body_shift = _body_shift_to_pals(pals, element.misalignment, extras)
     kwargs = _common_kwargs_from_extras(pals.Quadrupole, extras)
 
     return pals.Quadrupole(
         name=element.name,
-        length=_nonnegative_length(element.length, element.name),
+        length=_t2f(element.length),
+        BodyShiftP=body_shift,
         MagneticMultipoleP=multipole,
         **kwargs,
     )
@@ -374,6 +371,7 @@ def _quad_from_pals(element, factory_kwargs: dict) -> cheetah.Quadrupole:
     converted = cheetah.Quadrupole(
         length=_f2t(element.length, **factory_kwargs),
         k1=_f2t(k1, **factory_kwargs),
+        misalignment=_misalignment_from_body_shift(element, factory_kwargs),
         tilt=_f2t(tilt, **factory_kwargs),
         name=element.name,
     )
@@ -391,18 +389,16 @@ def _quad_from_pals(element, factory_kwargs: dict) -> cheetah.Quadrupole:
     extras = _extract_extras(
         element,
         consumed_fields={"length"},
-        consumed_groups={"MagneticMultipoleP": consumed},
+        consumed_groups={
+            "BodyShiftP": {"x_offset", "y_offset"},
+            "MagneticMultipoleP": consumed,
+        },
         converter_metadata=metadata or None,
     )
     return _attach_pals_extras(converted, extras)
 
 
 def _dipole_to_pals(element: cheetah.Dipole, pals):
-    _require_default(
-        element.tracking_method == "linear",
-        f"Dipole {element.name!r} uses unsupported tracking_method "
-        f"{element.tracking_method!r}.",
-    )
     _require_default(
         _is_zero(element.gap) and _is_zero(element.gap_exit),
         f"Dipole {element.name!r} has unsupported gap settings.",
@@ -417,7 +413,7 @@ def _dipole_to_pals(element: cheetah.Dipole, pals):
     )
 
     metadata, extras = _split_pals_extras(element)
-    length = _nonnegative_length(element.length, element.name)
+    length = _t2f(element.length)
     angle = _t2f(element.angle)
     if length == 0.0 and angle != 0.0:
         raise ValueError(f"Dipole {element.name!r} has nonzero angle and zero length.")
@@ -517,7 +513,7 @@ def _cavity_to_pals(element: cheetah.Cavity, pals):
     kwargs = _common_kwargs_from_extras(pals.RFCavity, extras)
     return pals.RFCavity(
         name=element.name,
-        length=_nonnegative_length(element.length, element.name),
+        length=_t2f(element.length),
         RFP=rf,
         **kwargs,
     )
@@ -547,7 +543,7 @@ def _corrector_multipole_to_pals(element: cheetah.Element, pals, data: dict):
     kwargs = _common_kwargs_from_extras(pals.Kicker, extras)
     return pals.Kicker(
         name=element.name,
-        length=_nonnegative_length(element.length, element.name),
+        length=_t2f(element.length),
         MagneticMultipoleP=multipole,
         **kwargs,
     )
@@ -622,11 +618,6 @@ def _kicker_from_pals(element, factory_kwargs: dict) -> cheetah.Element:
 
 
 def _solenoid_to_pals(element: cheetah.Solenoid, pals):
-    _require_default(
-        _is_zero(element.misalignment),
-        f"Solenoid {element.name!r} has unsupported misalignment.",
-    )
-
     _, extras = _split_pals_extras(element)
     solenoid = _merge_group(
         pals,
@@ -634,10 +625,12 @@ def _solenoid_to_pals(element: cheetah.Solenoid, pals):
         {"Ksol": _t2f(element.k)},
         extras,
     )
+    body_shift = _body_shift_to_pals(pals, element.misalignment, extras)
     kwargs = _common_kwargs_from_extras(pals.Solenoid, extras)
     return pals.Solenoid(
         name=element.name,
-        length=_nonnegative_length(element.length, element.name),
+        length=_t2f(element.length),
+        BodyShiftP=body_shift,
         SolenoidP=solenoid,
         **kwargs,
     )
@@ -648,12 +641,16 @@ def _solenoid_from_pals(element, factory_kwargs: dict) -> cheetah.Solenoid:
     converted = cheetah.Solenoid(
         length=_f2t(element.length, **factory_kwargs),
         k=_f2t(solenoid.get("Ksol", 0.0), **factory_kwargs),
+        misalignment=_misalignment_from_body_shift(element, factory_kwargs),
         name=element.name,
     )
     extras = _extract_extras(
         element,
         consumed_fields={"length"},
-        consumed_groups={"SolenoidP": {"Ksol"}},
+        consumed_groups={
+            "BodyShiftP": {"x_offset", "y_offset"},
+            "SolenoidP": {"Ksol"},
+        },
     )
     return _attach_pals_extras(converted, extras)
 
@@ -784,6 +781,9 @@ def convert_lattice_from_pals(
     """
     Convert a PALS Lattice, BeamLine, or PALSroot to a Cheetah segment.
 
+    PALS does not encode Cheetah-only simulation settings such as
+    `tracking_method`; set those manually on the returned elements as needed.
+
     :param obj: PALS object to convert. May be a `Lattice`, `BeamLine`,
         `PALSroot`, or individual PALS element.
     :param device: Device to use for converted tensors. If `None`, uses the
@@ -837,6 +837,9 @@ def load_lattice_from_pals(
 ) -> cheetah.Segment:
     """
     Load a Cheetah segment from a PALS file.
+
+    PALS does not encode Cheetah-only simulation settings such as
+    `tracking_method`; set those manually on the returned elements as needed.
 
     :param filename: Path to the PALS file to read.
     :param device: Device to use for converted tensors. If `None`, uses the

--- a/tests/test_pals_conversion.py
+++ b/tests/test_pals_conversion.py
@@ -20,7 +20,7 @@ def assert_tensor_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
     assert torch.allclose(actual, expected)
 
 
-def assert_v1_roundtrip_equal(
+def assert_roundtrip_equal(
     original: cheetah.Segment, converted: cheetah.Segment
 ) -> None:
     assert converted.name == original.name
@@ -81,6 +81,7 @@ def cheetah_test_segment(dtype: torch.dtype = torch.float32) -> cheetah.Segment:
             cheetah.Quadrupole(
                 length=torch.tensor(1.0, dtype=dtype),
                 k1=torch.tensor(2.0, dtype=dtype),
+                misalignment=torch.tensor([0.01, -0.02], dtype=dtype),
                 tilt=torch.tensor(0.1, dtype=dtype),
                 name="q1",
             ),
@@ -127,6 +128,7 @@ def cheetah_test_segment(dtype: torch.dtype = torch.float32) -> cheetah.Segment:
             cheetah.Solenoid(
                 length=torch.tensor(0.2, dtype=dtype),
                 k=torch.tensor(0.5, dtype=dtype),
+                misalignment=torch.tensor([-0.03, 0.04], dtype=dtype),
                 name="sol1",
             ),
             cheetah.Marker(name="m1"),
@@ -190,20 +192,20 @@ def test_pals_example_fodo_roundtrip():
 
 
 @pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
-def test_v1_elements_roundtrip():
+def test_elements_roundtrip():
     original = cheetah_test_segment()
 
     converted = cheetah_pals.convert_lattice_from_pals(
-        cheetah_pals.convert_lattice_to_pals(original, name="v1_lattice")
+        cheetah_pals.convert_lattice_to_pals(original, name="pals_lattice")
     )
 
-    assert_v1_roundtrip_equal(original, converted)
+    assert_roundtrip_equal(original, converted)
 
 
 @pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
 def test_extended_elements_to_pals_shape():
     lattice = cheetah_pals.convert_lattice_to_pals(
-        cheetah_test_segment(), name="v1_lattice"
+        cheetah_test_segment(), name="pals_lattice"
     )
     by_name = {element.name: element for element in lattice.branches[0].line}
 
@@ -217,6 +219,9 @@ def test_extended_elements_to_pals_shape():
     assert by_name["cav1"].RFP.frequency == pytest.approx(1.3e9)
     assert by_name["cav1"].RFP.phase == pytest.approx(math.pi / 6.0)
 
+    assert by_name["q1"].BodyShiftP.x_offset == pytest.approx(0.01)
+    assert by_name["q1"].BodyShiftP.y_offset == pytest.approx(-0.02)
+
     assert by_name["hcor1"].kind == "Kicker"
     assert by_name["hcor1"].MagneticMultipoleP.Kn0 == pytest.approx(1.0e-3)
     assert by_name["vcor1"].MagneticMultipoleP.Ks0 == pytest.approx(-2.0e-3)
@@ -224,6 +229,8 @@ def test_extended_elements_to_pals_shape():
     assert by_name["ccor1"].MagneticMultipoleP.Ks0 == pytest.approx(-4.0e-3)
 
     assert by_name["sol1"].kind == "Solenoid"
+    assert by_name["sol1"].BodyShiftP.x_offset == pytest.approx(-0.03)
+    assert by_name["sol1"].BodyShiftP.y_offset == pytest.approx(0.04)
     assert by_name["sol1"].SolenoidP.Ksol == pytest.approx(0.5)
 
 
@@ -291,7 +298,7 @@ def test_file_io_roundtrip(tmp_path):
 
         converted = cheetah_pals.load_lattice_from_pals(filename)
 
-        assert_v1_roundtrip_equal(original, converted)
+        assert_roundtrip_equal(original, converted)
 
 
 @pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
@@ -302,13 +309,13 @@ def test_segment_pals_methods(tmp_path):
     converted = cheetah.Segment.from_pals(lattice)
 
     assert isinstance(lattice, pals.Lattice)
-    assert_v1_roundtrip_equal(original, converted)
+    assert_roundtrip_equal(original, converted)
 
     filename = tmp_path / "segment_methods.pals.json"
     original.to_pals_file(filename, name="segment_methods_file")
     loaded = cheetah.Segment.from_pals_file(filename)
 
-    assert_v1_roundtrip_equal(original, loaded)
+    assert_roundtrip_equal(original, loaded)
 
 
 def test_pals_extras_roundtrip():
@@ -326,13 +333,16 @@ def test_pals_extras_roundtrip():
 
     segment = cheetah_pals.convert_lattice_from_pals(beamline)
 
-    assert segment.q1.pals_extras["BodyShiftP"]["x_offset"] == pytest.approx(0.5)
+    assert_tensor_equal(segment.q1.misalignment, torch.tensor([0.5, 0.0]))
+    assert "x_offset" not in segment.q1.pals_extras.get("BodyShiftP", {})
+    assert "y_offset" not in segment.q1.pals_extras.get("BodyShiftP", {})
     assert segment.q1.pals_extras["MagneticMultipoleP"]["Kn2"] == pytest.approx(5.0)
 
     lattice = cheetah_pals.convert_lattice_to_pals(segment)
     roundtrip_quad = lattice.branches[0].line[0]
 
     assert roundtrip_quad.BodyShiftP.x_offset == pytest.approx(0.5)
+    assert roundtrip_quad.BodyShiftP.y_offset == pytest.approx(0.0)
     assert roundtrip_quad.MagneticMultipoleP.Kn2 == pytest.approx(5.0)
 
 

--- a/tests/test_pals_conversion.py
+++ b/tests/test_pals_conversion.py
@@ -1,0 +1,368 @@
+import math
+
+import pytest
+import torch
+
+import cheetah
+from cheetah.converters import pals as cheetah_pals
+
+pals = pytest.importorskip("pals")
+
+UNDER_CONSTRUCTION_WARNING = (
+    "ignore:The .* element is marked as 'Under Construction' in the PALS "
+    "standard:UserWarning"
+)
+
+
+def assert_tensor_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    """Test that values and dypes of two tensors are equal."""
+    assert actual.dtype == expected.dtype
+    assert torch.allclose(actual, expected)
+
+
+def assert_v1_roundtrip_equal(
+    original: cheetah.Segment, converted: cheetah.Segment
+) -> None:
+    assert converted.name == original.name
+    assert len(converted.elements) == len(original.elements)
+
+    for actual, expected in zip(converted.elements, original.elements):
+        assert actual.name == expected.name
+        assert actual.__class__ is expected.__class__
+
+        if isinstance(expected, cheetah.Drift):
+            assert_tensor_equal(actual.length, expected.length)
+        elif isinstance(expected, cheetah.Quadrupole):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.k1, expected.k1)
+            assert_tensor_equal(actual.tilt, expected.tilt)
+        elif isinstance(expected, cheetah.Dipole):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.angle, expected.angle)
+            assert_tensor_equal(actual.k1, expected.k1)
+            assert_tensor_equal(actual.dipole_e1, expected.dipole_e1)
+            assert_tensor_equal(actual.dipole_e2, expected.dipole_e2)
+            assert_tensor_equal(actual.tilt, expected.tilt)
+            assert_tensor_equal(actual.fringe_integral, expected.fringe_integral)
+            assert_tensor_equal(
+                actual.fringe_integral_exit, expected.fringe_integral_exit
+            )
+        elif isinstance(expected, cheetah.Aperture):
+            assert_tensor_equal(actual.x_max, expected.x_max)
+            assert_tensor_equal(actual.y_max, expected.y_max)
+            assert actual.shape == expected.shape
+            assert actual.is_active == expected.is_active
+        elif isinstance(expected, cheetah.Cavity):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.voltage, expected.voltage)
+            assert_tensor_equal(actual.phase, expected.phase)
+            assert_tensor_equal(actual.frequency, expected.frequency)
+            assert actual.cavity_type == expected.cavity_type
+        elif isinstance(expected, cheetah.HorizontalCorrector):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.angle, expected.angle)
+        elif isinstance(expected, cheetah.VerticalCorrector):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.angle, expected.angle)
+        elif isinstance(expected, cheetah.CombinedCorrector):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.horizontal_angle, expected.horizontal_angle)
+            assert_tensor_equal(actual.vertical_angle, expected.vertical_angle)
+        elif isinstance(expected, cheetah.Solenoid):
+            assert_tensor_equal(actual.length, expected.length)
+            assert_tensor_equal(actual.k, expected.k)
+            assert_tensor_equal(actual.misalignment, expected.misalignment)
+
+
+def cheetah_test_segment(dtype: torch.dtype = torch.float32) -> cheetah.Segment:
+    return cheetah.Segment(
+        [
+            cheetah.Drift(length=torch.tensor(0.25, dtype=dtype), name="d1"),
+            cheetah.Quadrupole(
+                length=torch.tensor(1.0, dtype=dtype),
+                k1=torch.tensor(2.0, dtype=dtype),
+                tilt=torch.tensor(0.1, dtype=dtype),
+                name="q1",
+            ),
+            cheetah.Dipole(
+                length=torch.tensor(0.5, dtype=dtype),
+                angle=torch.tensor(0.05, dtype=dtype),
+                k1=torch.tensor(0.3, dtype=dtype),
+                dipole_e1=torch.tensor(0.01, dtype=dtype),
+                dipole_e2=torch.tensor(0.02, dtype=dtype),
+                tilt=torch.tensor(0.03, dtype=dtype),
+                fringe_integral=torch.tensor(0.4, dtype=dtype),
+                fringe_integral_exit=torch.tensor(0.5, dtype=dtype),
+                name="b1",
+            ),
+            cheetah.Aperture(
+                x_max=torch.tensor(0.01, dtype=dtype),
+                y_max=torch.tensor(0.02, dtype=dtype),
+                shape="elliptical",
+                name="ap1",
+            ),
+            cheetah.Cavity(
+                length=torch.tensor(0.3, dtype=dtype),
+                voltage=torch.tensor(1.0e6, dtype=dtype),
+                phase=torch.tensor(30.0, dtype=dtype),
+                frequency=torch.tensor(1.3e9, dtype=dtype),
+                name="cav1",
+            ),
+            cheetah.HorizontalCorrector(
+                length=torch.tensor(0.1, dtype=dtype),
+                angle=torch.tensor(1.0e-3, dtype=dtype),
+                name="hcor1",
+            ),
+            cheetah.VerticalCorrector(
+                length=torch.tensor(0.1, dtype=dtype),
+                angle=torch.tensor(-2.0e-3, dtype=dtype),
+                name="vcor1",
+            ),
+            cheetah.CombinedCorrector(
+                length=torch.tensor(0.1, dtype=dtype),
+                horizontal_angle=torch.tensor(3.0e-3, dtype=dtype),
+                vertical_angle=torch.tensor(-4.0e-3, dtype=dtype),
+                name="ccor1",
+            ),
+            cheetah.Solenoid(
+                length=torch.tensor(0.2, dtype=dtype),
+                k=torch.tensor(0.5, dtype=dtype),
+                name="sol1",
+            ),
+            cheetah.Marker(name="m1"),
+        ],
+        name="cell",
+    )
+
+
+def test_convert_lattice_to_pals_fodo_shape():
+    segment = cheetah.Segment(
+        [
+            cheetah.Drift(length=torch.tensor(0.25), name="d1"),
+            cheetah.Quadrupole(
+                length=torch.tensor(1.0), k1=torch.tensor(1.2), name="qf"
+            ),
+            cheetah.Drift(length=torch.tensor(0.5), name="d2"),
+            cheetah.Quadrupole(
+                length=torch.tensor(1.0), k1=torch.tensor(-1.2), name="qd"
+            ),
+            cheetah.Drift(length=torch.tensor(0.25), name="d3"),
+        ],
+        name="fodo",
+    )
+
+    lattice = cheetah_pals.convert_lattice_to_pals(segment, name="fodo_lattice")
+
+    assert isinstance(lattice, pals.Lattice)
+    assert lattice.name == "fodo_lattice"
+    assert len(lattice.branches) == 1
+    assert [element.kind for element in lattice.branches[0].line] == [
+        "Drift",
+        "Quadrupole",
+        "Drift",
+        "Quadrupole",
+        "Drift",
+    ]
+    assert lattice.branches[0].line[1].MagneticMultipoleP.Kn1 == pytest.approx(1.2)
+
+
+def test_pals_example_fodo_roundtrip():
+    drift1 = pals.Drift(name="drift1", length=0.25)
+    quad1 = pals.Quadrupole(
+        name="quad1",
+        length=1.0,
+        MagneticMultipoleP=pals.MagneticMultipoleParameters(Bn1=1.0),
+    )
+    drift2 = pals.Drift(name="drift2", length=0.5)
+    quad2 = pals.Quadrupole(
+        name="quad2",
+        length=1.0,
+        MagneticMultipoleP=pals.MagneticMultipoleParameters(Bn1=-1.0),
+    )
+    drift3 = pals.Drift(name="drift3", length=0.5)
+    line = pals.BeamLine(name="fodo_cell", line=[drift1, quad1, drift2, quad2, drift3])
+    lattice = pals.Lattice(name="fodo_lattice", branches=[line])
+
+    segment = cheetah_pals.convert_lattice_from_pals(lattice)
+    roundtrip = cheetah_pals.convert_lattice_to_pals(segment, name="fodo_lattice")
+
+    assert roundtrip == lattice
+
+
+@pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
+def test_v1_elements_roundtrip():
+    original = cheetah_test_segment()
+
+    converted = cheetah_pals.convert_lattice_from_pals(
+        cheetah_pals.convert_lattice_to_pals(original, name="v1_lattice")
+    )
+
+    assert_v1_roundtrip_equal(original, converted)
+
+
+@pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
+def test_extended_elements_to_pals_shape():
+    lattice = cheetah_pals.convert_lattice_to_pals(
+        cheetah_test_segment(), name="v1_lattice"
+    )
+    by_name = {element.name: element for element in lattice.branches[0].line}
+
+    assert by_name["ap1"].kind == "Marker"
+    assert by_name["ap1"].ApertureP.shape == "ELLIPTICAL"
+    assert by_name["ap1"].ApertureP.x_limits == pytest.approx([-0.01, 0.01])
+    assert by_name["ap1"].ApertureP.y_limits == pytest.approx([-0.02, 0.02])
+
+    assert by_name["cav1"].kind == "RFCavity"
+    assert by_name["cav1"].RFP.voltage == pytest.approx(1.0e6)
+    assert by_name["cav1"].RFP.frequency == pytest.approx(1.3e9)
+    assert by_name["cav1"].RFP.phase == pytest.approx(math.pi / 6.0)
+
+    assert by_name["hcor1"].kind == "Kicker"
+    assert by_name["hcor1"].MagneticMultipoleP.Kn0 == pytest.approx(1.0e-3)
+    assert by_name["vcor1"].MagneticMultipoleP.Ks0 == pytest.approx(-2.0e-3)
+    assert by_name["ccor1"].MagneticMultipoleP.Kn0 == pytest.approx(3.0e-3)
+    assert by_name["ccor1"].MagneticMultipoleP.Ks0 == pytest.approx(-4.0e-3)
+
+    assert by_name["sol1"].kind == "Solenoid"
+    assert by_name["sol1"].SolenoidP.Ksol == pytest.approx(0.5)
+
+
+@pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
+def test_zero_correctors_roundtrip_by_multipole_key():
+    segment = cheetah.Segment(
+        [
+            cheetah.HorizontalCorrector(
+                length=torch.tensor(0.1), angle=torch.tensor(0.0), name="hcor"
+            ),
+            cheetah.VerticalCorrector(
+                length=torch.tensor(0.1), angle=torch.tensor(0.0), name="vcor"
+            ),
+            cheetah.CombinedCorrector(
+                length=torch.tensor(0.1),
+                horizontal_angle=torch.tensor(0.0),
+                vertical_angle=torch.tensor(0.0),
+                name="ccor",
+            ),
+        ],
+        name="zero_correctors",
+    )
+
+    converted = cheetah_pals.convert_lattice_from_pals(
+        cheetah_pals.convert_lattice_to_pals(segment)
+    )
+
+    assert isinstance(converted.hcor, cheetah.HorizontalCorrector)
+    assert isinstance(converted.vcor, cheetah.VerticalCorrector)
+    assert isinstance(converted.ccor, cheetah.CombinedCorrector)
+
+
+def test_convert_lattice_from_pals_dtype_and_multipole_family_roundtrip():
+    beamline = pals.BeamLine(
+        name="line",
+        line=[
+            pals.Quadrupole(
+                name="q1",
+                length=1.0,
+                MagneticMultipoleP=pals.MagneticMultipoleParameters(Bn1=3.0, tilt1=0.2),
+            )
+        ],
+    )
+
+    segment = cheetah_pals.convert_lattice_from_pals(beamline, dtype=torch.float64)
+
+    assert segment.q1.length.dtype == torch.float64
+    assert segment.q1.k1.dtype == torch.float64
+    assert torch.isclose(segment.q1.k1, torch.tensor(3.0, dtype=torch.float64))
+    assert torch.isclose(segment.q1.tilt, torch.tensor(0.2, dtype=torch.float64))
+
+    lattice = cheetah_pals.convert_lattice_to_pals(segment)
+    multipole = lattice.branches[0].line[0].MagneticMultipoleP.model_dump()
+    assert multipole["Bn1"] == pytest.approx(3.0)
+    assert "Kn1" not in multipole
+
+
+@pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
+def test_file_io_roundtrip(tmp_path):
+    original = cheetah_test_segment()
+
+    for suffix in ("yaml", "json"):
+        filename = tmp_path / f"lattice.pals.{suffix}"
+        cheetah_pals.save_lattice_to_pals(original, filename, name="saved_lattice")
+
+        converted = cheetah_pals.load_lattice_from_pals(filename)
+
+        assert_v1_roundtrip_equal(original, converted)
+
+
+@pytest.mark.filterwarnings(UNDER_CONSTRUCTION_WARNING)
+def test_segment_pals_methods(tmp_path):
+    original = cheetah_test_segment()
+
+    lattice = original.to_pals(name="segment_methods")
+    converted = cheetah.Segment.from_pals(lattice)
+
+    assert isinstance(lattice, pals.Lattice)
+    assert_v1_roundtrip_equal(original, converted)
+
+    filename = tmp_path / "segment_methods.pals.json"
+    original.to_pals_file(filename, name="segment_methods_file")
+    loaded = cheetah.Segment.from_pals_file(filename)
+
+    assert_v1_roundtrip_equal(original, loaded)
+
+
+def test_pals_extras_roundtrip():
+    beamline = pals.BeamLine(
+        name="line",
+        line=[
+            pals.Quadrupole(
+                name="q1",
+                length=1.0,
+                BodyShiftP=pals.BodyShiftParameters(x_offset=0.5),
+                MagneticMultipoleP=pals.MagneticMultipoleParameters(Kn1=2.0, Kn2=5.0),
+            )
+        ],
+    )
+
+    segment = cheetah_pals.convert_lattice_from_pals(beamline)
+
+    assert segment.q1.pals_extras["BodyShiftP"]["x_offset"] == pytest.approx(0.5)
+    assert segment.q1.pals_extras["MagneticMultipoleP"]["Kn2"] == pytest.approx(5.0)
+
+    lattice = cheetah_pals.convert_lattice_to_pals(segment)
+    roundtrip_quad = lattice.branches[0].line[0]
+
+    assert roundtrip_quad.BodyShiftP.x_offset == pytest.approx(0.5)
+    assert roundtrip_quad.MagneticMultipoleP.Kn2 == pytest.approx(5.0)
+
+
+def test_unknown_pals_element_becomes_marker():
+    with pytest.warns(UserWarning, match="Under Construction"):
+        unknown = pals.NullEle(name="unknown")
+    beamline = pals.BeamLine(name="line", line=[unknown])
+
+    with pytest.warns(cheetah.UnknownElementWarning):
+        segment = cheetah_pals.convert_lattice_from_pals(beamline)
+
+    assert isinstance(segment.unknown, cheetah.Marker)
+    assert segment.unknown.pals_extras["kind"] == "NullEle"
+
+
+def test_unknown_cheetah_element_rejected():
+    segment = cheetah.Segment(
+        [cheetah.Sextupole(length=torch.tensor(1.0), k2=torch.tensor(2.0), name="s1")],
+        name="unsupported",
+    )
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        cheetah_pals.convert_lattice_to_pals(segment)
+
+
+def test_batched_tensor_rejected():
+    segment = cheetah.Segment(
+        [cheetah.Drift(length=torch.tensor([1.0, 2.0]), name="d1")],
+        name="batched",
+    )
+
+    with pytest.raises(ValueError, match="scalar"):
+        cheetah_pals.convert_lattice_to_pals(segment)


### PR DESCRIPTION

Adds PALS lattice conversion support for Cheetah interfacing with the [pals-python](https://github.com/pals-project/pals-python) project.

Essentially it builds a two-directional mapping between `pals-python` objects and Cheetah objects.

## Description

- Adds `cheetah.converters.pals` with conversion to/from PALS objects and lattice files.
- Supports drift, marker, quadrupole, dipole, aperture, RF cavity, horizontal/vertical/combined correctors, and solenoid.
- Adds `Segment` convenience methods:
  - `Segment.from_pals(...)`
  - `segment.to_pals(...)`
  - `Segment.from_pals_file(...)`
  - `segment.to_pals_file(...)`

This is still an experimental implementation as the PALS and pals-python are both evolving.

To handle the extra fields:
PALS fields that Cheetah does not model directly are preserved in `element.pals_extras`.

- `_extract_extras(...)` stores unconsumed PALS fields/groups during PALS -> Cheetah conversion.
- `_merge_group(...)` and `_split_pals_extras(...)` re-emit preserved data during Cheetah -> PALS conversion, so that the round-trip is possible.
- Unknown PALS element kinds become `cheetah.Marker` with the full PALS payload stored in `pals_extras`, plus an `UnknownElementWarning`.
- Unsupported Cheetah elements or lossy conversions raise `NotImplementedError`.

## Tests

Added PALS conversion tests for:
- In-memory round trips
- File round trips
- Extra PALS parameter preservation
- Unknown PALS element fallback
- Unsupported Cheetah element rejection
- New `Segment` PALS helper methods

Verified with:
- `pytest tests/test_pals_conversion.py`
- `pytest tests/test_pals_conversion.py tests/test_lattice_json.py tests/test_bmad_conversion.py`
- `pytest --ignore=tests/test_3d_visualization.py`

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [ ] I have reformatted the code and checked that formatting passes (**required**).
- [ ] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [ ] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
