### PR TITLE
Make `Sextupole` skippable if its tracking method is set to linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 ### 🐛 Bug fixes
 
-- Make `Sextupole` skippable if its tracking method is set to `linear` (see #655) (@hespe)
+- Fix `Sextupole` not being skippable if its tracking method is set to `linear` (see #655) (@hespe)
 
 ### 🐆 Other
+
+- Non-deterministic torch features now raise a warning in tests instead of a failure (see #655) (@hespe, @jank324)
 
 ### 🌟 First Time Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@
 ### 🐛 Bug fixes
 
 - Fix `Sextupole` not being skippable if its tracking method is set to `linear` (see #655) (@hespe)
-- Fix issue where `ParticleBeam.randomly_subsampled` method would not be stochastic if the `random_state` argument was not passed. This also fixes a test failure introduced by changes on the MPS backend in PyTorch 2.13. (see #655) (@jank324)
+- Fix issue where `ParticleBeam.randomly_subsampled` method would not be stochastic if the `random_state` argument was not passed. This also fixes a test failure introduced by changes on the MPS backend in PyTorch 2.13. (see #655) (@jank324, @hespe)
 
 ### 🐆 Other
 
-- Non-deterministic torch features now raise a warning in tests instead of a failure (see #655) (@hespe, @jank324)
+- Non-deterministic torch features now raise a warning in tests instead of a failure. This also fixes a test failure introduced by changes on the MPS backend in PyTorch 2.13. (see #655) (@hespe, @jank324)
 
 ### 🌟 First Time Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `Sextupole` not being skippable if its tracking method is set to `linear` (see #655) (@hespe)
+- Fix issue where `ParticleBeam.randomly_subsampled` method would not be stochastic if the `random_state` argument was not passed. This also fixes a test failure introduced by changes on the MPS backend in PyTorch 2.13. (see #655) (@jank324)
 
 ### 🐆 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Make `Sextupole` skippable if its tracking method is set to `linear` (see #655) (@hespe)
+
 ### 🐆 Other
 
 ### 🌟 First Time Contributors

--- a/cheetah/accelerator/sextupole.py
+++ b/cheetah/accelerator/sextupole.py
@@ -117,7 +117,7 @@ class Sextupole(Element):
 
     @property
     def is_skippable(self) -> bool:
-        return False
+        return self.tracking_method == "linear"
 
     @property
     def is_active(self) -> bool:

--- a/cheetah/particles/particle_beam.py
+++ b/cheetah/particles/particle_beam.py
@@ -1231,11 +1231,8 @@ class ParticleBeam(Beam):
             "particles in the original beam."
         )
 
-        if random_state is None:
-            random_state = torch.Generator(device=self.particles.device)
-
         randomly_permuted_particle_indices = torch.randperm(
-            self.num_particles, generator=random_state, device=random_state.device
+            self.num_particles, generator=random_state, device=self.particles.device
         )
         subsampled_particle_indices = randomly_permuted_particle_indices[:num_particles]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def seed_random_generators(request):
     seed = request.config.getoption("--seed")
 
     # Prevent torch from using non-deterministic algorithms
-    torch.use_deterministic_algorithms(True)
+    torch.use_deterministic_algorithms(True, warn_only=True)
 
     # Manually seed all torch PRNGs
     torch.manual_seed(seed)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -30,9 +30,12 @@ def test_all_element_subclasses_is_skippable_boolean(element):
     except_if=lambda element: "linear" not in element.supported_tracking_methods,
 )
 def test_linear_tracking_is_skippable(element: cheetah.Element):
-    """Test that all elements supporting `tracking_method` to be set to `"linear"` are skippable when it is set to `"linear"`."""
+    """
+    Test that all elements supporting `tracking_method` to be set to `"linear"` are
+    skippable when it is set to `"linear"`.
+    """
     element.tracking_method = "linear"
-    
+
     assert element.is_skippable
 
 
@@ -42,10 +45,11 @@ def test_linear_tracking_is_skippable(element: cheetah.Element):
 )
 def test_second_order_tracking_is_not_skippable(element: cheetah.Element):
     """
-    Test that elements with their `tracking_method` set to `second_order` are not skippable.
+    Test that elements with their `tracking_method` set to `second_order` are not
+    skippable.
     """
     element.tracking_method = "second_order"
-    
+
     assert not element.is_skippable
 
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -25,6 +25,30 @@ def test_all_element_subclasses_is_skippable_boolean(element):
     assert isinstance(element.is_skippable, bool)
 
 
+@pytest.mark.for_every_element(
+    "element",
+    except_if=lambda element: "linear" not in element.supported_tracking_methods,
+)
+def test_linear_tracking_is_skippable(element: cheetah.Element):
+    """Test that all elements with `tracking_method` set to `linear` are skippable."""
+
+    element.tracking_method = "linear"
+    assert element.is_skippable
+
+
+@pytest.mark.for_every_element(
+    "element",
+    except_if=lambda element: "second_order" not in element.supported_tracking_methods,
+)
+def test_second_order_tracking_is_not_skippable(element: cheetah.Element):
+    """
+    Test that no elements with `tracking_method` set to `second_order` is skippable.
+    """
+
+    element.tracking_method = "second_order"
+    assert not element.is_skippable
+
+
 @pytest.mark.for_every_element("element")
 def test_defining_features_dtype(element):
     """

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -30,9 +30,9 @@ def test_all_element_subclasses_is_skippable_boolean(element):
     except_if=lambda element: "linear" not in element.supported_tracking_methods,
 )
 def test_linear_tracking_is_skippable(element: cheetah.Element):
-    """Test that all elements with `tracking_method` set to `linear` are skippable."""
-
+    """Test that all elements supporting `tracking_method` to be set to `"linear"` are skippable when it is set to `"linear"`."""
     element.tracking_method = "linear"
+    
     assert element.is_skippable
 
 
@@ -42,10 +42,10 @@ def test_linear_tracking_is_skippable(element: cheetah.Element):
 )
 def test_second_order_tracking_is_not_skippable(element: cheetah.Element):
     """
-    Test that no elements with `tracking_method` set to `second_order` is skippable.
+    Test that elements with their `tracking_method` set to `second_order` are not skippable.
     """
-
     element.tracking_method = "second_order"
+    
     assert not element.is_skippable
 
 

--- a/tests/test_particle_beam.py
+++ b/tests/test_particle_beam.py
@@ -374,7 +374,7 @@ def test_random_subsample_gaussian_properties(device: torch.device):
     assert torch.isclose(
         subsampled_beam.mu_tau, original_beam.mu_tau, rtol=1e-5, atol=1e-5
     )
-    assert torch.isclose(subsampled_beam.mu_p, original_beam.mu_p, rtol=1e-5, atol=1e-5)
+    assert torch.isclose(subsampled_beam.mu_p, original_beam.mu_p, rtol=1e-5, atol=2e-5)
     assert torch.isclose(
         subsampled_beam.sigma_x, original_beam.sigma_x, rtol=1e-5, atol=1e-5
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

`Sextupole` is currently never skippable. However, if its tracking method is `linear` this should be possible.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- - [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**) -->

- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (_required for a bug fix or a new feature_).
- [ ] I have updated the documentation accordingly.
  <!-- - [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) -->
  <!-- - [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) -->
- [x] I have reformatted the code and checked that formatting passes (**required**).
- [x] I have have fixed all issues found by `flake8` (**required**).
- [ ] I have ensured that all `pytest` tests pass (**required**).
- [ ] I have run `pytest` on a machine with a CUDA GPU and made sure all tests pass (**required**).
- [x] I have checked that the documentation builds (**required**).

Note: We are using a maximum length of 88 characters per line.

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3/ -->
