### PR TITLE
deps: bump tqdm to 4.66.3 in minimum requirements constraints

### DIFF
--- a/test_minimum_requirements_constraints.txt
+++ b/test_minimum_requirements_constraints.txt
@@ -4,5 +4,5 @@ openpmd-beamphysics==0.14.0
 requests==2.32.2
 scipy==1.10.1
 torch==2.3.0
-tqdm==4.66.0
+tqdm==4.66.3
 trimesh==4.4.0


### PR DESCRIPTION
> **Note:** `tqdm==4.66.0` in `test_minimum_requirements_constraints.txt` is also inside the affected range for GHSA-g7vv-2v7x-gj9p. This PR clears both advisories listed above.

Updates `tqdm` from 4.66.0 to 4.66.3 in `test_minimum_requirements_constraints.txt` to address PYSEC-2026-1976 and GHSA-g7vv-2v7x-gj9p.

Evidence:
- `test_minimum_requirements_constraints.txt` pinned `tqdm==4.66.0`
- `pip-audit` reported PYSEC-2026-1976 for tqdm 4.66.0 before the update
- affected range starts at 4.4.0, fixed in 4.66.3
- updated version: `4.66.3`

Validation:
- `pip-audit` no longer reports any advisory for tqdm 4.66.3 (verified in a clean venv: install 4.66.0, audit, upgrade to 4.66.3, audit again)
- `python -c "import tqdm; from tqdm import tqdm"` passes with 4.66.3
- the repo CI (`pytest --benchmark-skip` in `.github/workflows/pytest.yaml`) does not exercise tqdm directly; the constraints file only sets minimums for the min-requirements matrix job

Scope: `test_minimum_requirements_constraints.txt` only. The file's purpose is to pin the oldest supported versions, so if you would rather keep 4.66.0 as the floor and treat this as out of scope, feel free to close.
